### PR TITLE
Add retry() function to the loading component when import failed

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ will be `false`).
 ```js
 function Loading(props) {
   if (props.error) {
-    return <div>Error! <button type="button" onClick={ props.retry }>Retry</button></div>;
+    return <div>Error! <button onClick={ props.retry }>Retry</button></div>;
   } else {
     return <div>Loading...</div>;
   }
@@ -238,7 +238,7 @@ which will only be true once the component has taken longer to load than a set
 ```js
 function Loading(props) {
   if (props.error) {
-    return <div>Error! <button type="button" onClick={ props.retry }>Retry</button></div>;
+    return <div>Error! <button onClick={ props.retry }>Retry</button></div>;
   } else if (props.pastDelay) {
     return <div>Loading...</div>;
   } else {
@@ -271,9 +271,9 @@ The [loading component](#loadingcomponent) will receive a
 ```js
 function Loading(props) {
   if (props.error) {
-    return <div>Error! <button type="button" onClick={ props.retry }>Retry</button></div>;
+    return <div>Error! <button onClick={ props.retry }>Retry</button></div>;
   } else if (props.timedOut) {
-    return <div>Taking a long time... <button type="button" onClick={ props.retry }>Retry</button></div>;
+    return <div>Taking a long time... <button onClick={ props.retry }>Retry</button></div>;
   } else if (props.pastDelay) {
     return <div>Loading...</div>;
   } else {
@@ -831,10 +831,10 @@ This is the component you pass to [`opts.loading`](#optsloading).
 function LoadingComponent(props) {
   if (props.error) {
     // When the loader has errored
-    return <div>Error! <button type="button" onClick={ props.retry }>Retry</button></div>;
+    return <div>Error! <button onClick={ props.retry }>Retry</button></div>;
   } else if (props.timedOut) {
     // When the loader has taken longer than the timeout
-    return <div>Taking a long time... <button type="button" onClick={ props.retry }>Retry</button></div>;
+    return <div>Taking a long time... <button onClick={ props.retry }>Retry</button></div>;
   } else if (props.pastDelay) {
     // When the loader has taken longer than the delay
     return <div>Loading...</div>;
@@ -876,7 +876,7 @@ A function prop passed to [`LoadingComponent`](#loadingcomponent) when the
 ```js
 function LoadingComponent(props) {
   if (props.error) {
-    return <div>Error! <button type="button" onClick={ props.retry }>Retry</button></div>;
+    return <div>Error! <button onClick={ props.retry }>Retry</button></div>;
   } else {
     return <div>Loading...</div>;
   }

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ will be `false`).
 ```js
 function Loading(props) {
   if (props.error) {
-    return <div>Error!</div>;
+    return <div>Error! <button type="button" onClick={ props.retry }>Retry</button></div>;
   } else {
     return <div>Loading...</div>;
   }
@@ -238,7 +238,7 @@ which will only be true once the component has taken longer to load than a set
 ```js
 function Loading(props) {
   if (props.error) {
-    return <div>Error!</div>;
+    return <div>Error! <button type="button" onClick={ props.retry }>Retry</button></div>;
   } else if (props.pastDelay) {
     return <div>Loading...</div>;
   } else {
@@ -271,9 +271,9 @@ The [loading component](#loadingcomponent) will receive a
 ```js
 function Loading(props) {
   if (props.error) {
-    return <div>Error!</div>;
+    return <div>Error! <button type="button" onClick={ props.retry }>Retry</button></div>;
   } else if (props.timedOut) {
-    return <div>Taking a long time...</div>;
+    return <div>Taking a long time... <button type="button" onClick={ props.retry }>Retry</button></div>;
   } else if (props.pastDelay) {
     return <div>Loading...</div>;
   } else {
@@ -831,10 +831,10 @@ This is the component you pass to [`opts.loading`](#optsloading).
 function LoadingComponent(props) {
   if (props.error) {
     // When the loader has errored
-    return <div>Error!</div>;
+    return <div>Error! <button type="button" onClick={ props.retry }>Retry</button></div>;
   } else if (props.timedOut) {
     // When the loader has taken longer than the timeout
-    return <div>Taking a long time...</div>;
+    return <div>Taking a long time... <button type="button" onClick={ props.retry }>Retry</button></div>;
   } else if (props.pastDelay) {
     // When the loader has taken longer than the delay
     return <div>Loading...</div>;
@@ -860,6 +860,23 @@ A boolean prop passed to [`LoadingComponent`](#loadingcomponent) when the
 function LoadingComponent(props) {
   if (props.error) {
     return <div>Error!</div>;
+  } else {
+    return <div>Loading...</div>;
+  }
+}
+```
+
+[Read more about errors](#loading-error-states).
+
+#### `props.retry`
+
+A function prop passed to [`LoadingComponent`](#loadingcomponent) when the
+[`loader`](#optsloader) has failed, used to retry loading the component.
+
+```js
+function LoadingComponent(props) {
+  if (props.error) {
+    return <div>Error! <button type="button" onClick={ props.retry }>Retry</button></div>;
   } else {
     return <div>Loading...</div>;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -151,7 +151,10 @@ function createLoadableComponent(loadFn, options) {
 
     componentWillMount() {
       this._mounted = true;
+      this._loadModule();
+    }
 
+    _loadModule() {
       if (this.context.loadable && Array.isArray(opts.modules)) {
         opts.modules.forEach(moduleName => {
           this.context.loadable.report(moduleName);
@@ -210,13 +213,20 @@ function createLoadableComponent(loadFn, options) {
       clearTimeout(this._timeout);
     }
 
+    retry() {
+      this.setState({ error: null, loading: true });
+      res = loadFn(opts.loader);
+      this._loadModule();
+    };
+
     render() {
       if (this.state.loading || this.state.error) {
         return React.createElement(opts.loading, {
           isLoading: this.state.loading,
           pastDelay: this.state.pastDelay,
           timedOut: this.state.timedOut,
-          error: this.state.error
+          error: this.state.error,
+          retry: this.retry.bind(this)
         });
       } else if (this.state.loaded) {
         return opts.render(this.state.loaded, this.props);

--- a/src/index.js
+++ b/src/index.js
@@ -213,11 +213,11 @@ function createLoadableComponent(loadFn, options) {
       clearTimeout(this._timeout);
     }
 
-    retry() {
+    retry = () => {
       this.setState({ error: null, loading: true });
       res = loadFn(opts.loader);
       this._loadModule();
-    };
+    }
 
     render() {
       if (this.state.loading || this.state.error) {
@@ -226,7 +226,7 @@ function createLoadableComponent(loadFn, options) {
           pastDelay: this.state.pastDelay,
           timedOut: this.state.timedOut,
           error: this.state.error,
-          retry: this.retry.bind(this)
+          retry: this.retry
         });
       } else if (this.state.loaded) {
         return opts.render(this.state.loaded, this.props);


### PR DESCRIPTION
To improve the user experience, give the user a chance to retry loading the component when the import failed. The loading component receive a `retry` prop, which is a function to retry the operation.

```js
const Loading = props => {
  if (props.error) {
    return <div>Error! <button type="button" onClick={ props.retry }>Retry</button></div>;
  } else {
    return <div>Loading...</div>;
  }
};
```