### PR TITLE
Allow to display loading and loaded Component at the same time

### DIFF
--- a/__tests__/__snapshots__/test.js.snap
+++ b/__tests__/__snapshots__/test.js.snap
@@ -1,5 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`custom render 1`] = `
+<div>
+  <div>
+    loading...
+  </div>
+</div>
+`;
+
+exports[`custom render 2`] = `
+<div>
+  <div>
+    done loading, we could fade this out now
+  </div>
+  <div>
+    MyComponent 
+    {"prop":"foo"}
+  </div>
+</div>
+`;
+
 exports[`delay and timeout 1`] = `
 <div>
   MyLoadingComponent 

--- a/__tests__/test.js
+++ b/__tests__/test.js
@@ -151,6 +151,24 @@ test('render', async () => {
   expect(component.toJSON()).toMatchSnapshot(); // success
 });
 
+test('custom render', async () => {
+  let LoadableMyComponent = Loadable({
+    custom: ({isLoading, loaded, props}) => (
+      <div>
+        <div>{isLoading ? "loading..." : "done loading, we could fade this out now"}</div>
+        {loaded && React.createElement(loaded, props)}
+      </div>
+    ),
+    loader: createLoader(100, () => MyComponent)
+  });
+
+  let component1 = renderer.create(<LoadableMyComponent prop="foo" />);
+
+  expect(component1.toJSON()).toMatchSnapshot(); // initial
+  await waitFor(120);
+  expect(component1.toJSON()).toMatchSnapshot(); // loaded
+});
+
 test('loadable map success', async () => {
   let LoadableMyComponent = Loadable.Map({
     loader: {

--- a/src/index.js
+++ b/src/index.js
@@ -92,8 +92,8 @@ function render(loaded, props) {
 }
 
 function createLoadableComponent(loadFn, options) {
-  if (!options.loading) {
-    throw new Error('react-loadable requires a `loading` component')
+  if (!options.loading && !options.custom) {
+    throw new Error('react-loadable requires a `loading` component or a `custom` renderer')
   }
 
   let opts = Object.assign({
@@ -104,6 +104,7 @@ function createLoadableComponent(loadFn, options) {
     render: render,
     webpack: null,
     modules: null,
+    custom: null
   }, options);
 
   let res = null;
@@ -210,7 +211,16 @@ function createLoadableComponent(loadFn, options) {
     }
 
     render() {
-      if (this.state.loading || this.state.error) {
+      if (opts.custom) {
+        return opts.custom({
+          isLoading: this.state.loading,
+          pastDelay: this.state.pastDelay,
+          timedOut: this.state.timedOut,
+          error: this.state.error,
+          loaded: this.state.loaded,
+          props: this.props
+        })
+      } else if (this.state.loading || this.state.error) {
         return React.createElement(opts.loading, {
           isLoading: this.state.loading,
           pastDelay: this.state.pastDelay,


### PR DESCRIPTION
Think of a scenario where you're showing a loading spinner that you want to fade out once the content is loaded.
This would require the loading and the loaded component to be shown simultaneously. Something that the current `render` method of the `LoadableComponent` does not support.

This is why I'm suggesting to add a `custom` option to `Loadable` that gives the user full control over what is rendered. This would allow code like this:

```jsx
Loadable({
  loader: () => import("./MyComponent"),
  custom: ({isLoading, loaded, props}) => (
    <Motion style={{opacity: spring(isLoading ? 1 : 0)}}>
      {({opacity}) => (
        <div>
          {opacity !== 0 && <Spinner opacity={opacity}/>}
          {loaded && React.createElement(loaded, {opacity: 1 - opacity, ...props)}
        </div>
      )}
    </Motion>
  )
})
```

Please let me know how you feel about this change and I'm happy to add changes to the docs as well :)