### PR TITLE
Exclude main chunk from module-bundle map

### DIFF
--- a/src/webpack.js
+++ b/src/webpack.js
@@ -8,19 +8,21 @@ function buildManifest(compiler, compilation) {
   let manifest = {};
 
   compilation.chunks.forEach(chunk => {
-    chunk.files.forEach(file => {
-      chunk.forEachModule(module => {
-        let id = module.id;
-        let name = typeof module.libIdent === 'function' ? module.libIdent({ context }) : null;
-        let publicPath = url.resolve(compilation.outputOptions.publicPath || '', file);
+    if (chunk.name !== 'main') {
+      chunk.files.forEach(file => {
+        chunk.forEachModule(module => {
+          let id = module.id;
+          let name = typeof module.libIdent === 'function' ? module.libIdent({ context }) : null;
+          let publicPath = url.resolve(compilation.outputOptions.publicPath || '', file);
 
-        if (!manifest[module.rawRequest]) {
-          manifest[module.rawRequest] = [];
-        }
+          if (!manifest[module.rawRequest]) {
+            manifest[module.rawRequest] = [];
+          }
 
-        manifest[module.rawRequest].push({ id, name, file, publicPath });
+          manifest[module.rawRequest].push({ id, name, file, publicPath });
+        });
       });
-    });
+    }
   });
 
   return manifest;


### PR DESCRIPTION
Does the main bundle need to be included in the module-bundle map generated by the Loadable Webpack plugin?

The nature of using dynamic `import()` with `Loadable` means that no loadable component should ever reside in the main bundle.

```js
ReactDOMServer.renderToString(
    <Loadable.Capture report={moduleName => modules.push(moduleName)}>
      <App/>
    </Loadable.Capture>
  );
```

As a result, the above shouldn't ever capture the main module of the application. 

By excluding the main module in the plugin, it ensures that the output JSON **only** maps modules required by loadable components to the bundles that they reside in, instead of every single module in the app.