### PR TITLE
Improve rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1222,6 +1222,12 @@ export default {
 This will create a file (`opts.filename`) which you can import to map modules
 to bundles.
 
+### `opts.filename`
+Required, the destination file for writing react-loadable module data
+
+### `opts.ignoreChunkNames`
+Optional, an array of webpack chunk names to exclude from the module data
+
 [Read more about mapping modules to bundles](#mapping-loaded-modules-to-bundles).
 
 ### `getBundles`

--- a/README.md
+++ b/README.md
@@ -305,6 +305,8 @@ Loadable({
 
 ### Customizing rendering
 
+`render(state, props)` can access `state` and `props` to determine the current state of the loader.
+
 By default `Loadable` will render the `default` export of the returned module.
 If you want to customize this behavior you can use the
 [`render` option](#optsrender).
@@ -312,7 +314,12 @@ If you want to customize this behavior you can use the
 ```js
 Loadable({
   loader: () => import('./my-component'),
-  render(loaded, props) {
+  render(state, props) {
+    const { isLoading, pastDelay, timedOut, error, loaded } = state;
+    if (isLoading) {
+      return <div>Loading...</div>;
+    }
+
     let Component = loaded.namedExport;
     return <Component {...props}/>;
   }
@@ -334,7 +341,7 @@ Loadable.Map({
     Bar: () => import('./Bar'),
     i18n: () => fetch('./i18n/bar.json').then(res => res.json()),
   },
-  render(loaded, props) {
+  render({ loaded }, props) {
     let Bar = loaded.Bar.default;
     let i18n = loaded.i18n;
     return <Bar {...props} i18n={i18n}/>;
@@ -675,7 +682,7 @@ Loadable.Map({
     Bar: () => import('./Bar'),
     i18n: () => fetch('./i18n/bar.json').then(res => res.json()),
   },
-  render(loaded, props) {
+  render({ loaded }, props) {
     let Bar = loaded.Bar.default;
     let i18n = loaded.i18n;
     return <Bar {...props} i18n={i18n}/>;
@@ -770,7 +777,7 @@ and `props` which are the props passed to the
 
 ```js
 Loadable({
-  render(loaded, props) {
+  render({ loaded }, props) {
     let Component = loaded.default;
     return <Component {...props}/>;
   }

--- a/README.md
+++ b/README.md
@@ -305,11 +305,31 @@ Loadable({
 
 ### Customizing rendering
 
-`render(state, props)` can access `state` and `props` to determine the current state of the loader.
-
 By default `Loadable` will render the `default` export of the returned module.
 If you want to customize this behavior you can use the
 [`render` option](#optsrender).
+
+#### With a `loading` component
+
+When a `loading` prop is defined on Loadable, the `render` method is only invoked
+after the loader import has completed loading.
+
+```js
+Loadable({
+  loader: () => import('./my-component'),
+  loading: Loading,
+  render(loaded, props) {
+    let Component = loaded.namedExport;
+    return <Component {...props}/>;
+  }
+});
+```
+
+#### Without a `loading` component
+
+When no `loading` prop is defined on Loadable, `render(state, props)` can access
+`state` and `props` to determine the current state of the loader. `render` is invoked
+for every render of the component, regardless of the current loader state.
 
 ```js
 Loadable({
@@ -335,13 +355,41 @@ But writing it out can be a bit annoying.
 To make it easier to load multiple resources in parallel, you can use
 [`Loadable.Map`](#loadablemap).
 
+When using `Loadable.Map` the [`render()` method](#optsrender) is required.
+
+#### With a `loading` component
+
 ```js
 Loadable.Map({
   loader: {
     Bar: () => import('./Bar'),
     i18n: () => fetch('./i18n/bar.json').then(res => res.json()),
   },
-  render({ loaded }, props) {
+  loading: Loading,
+  render(loaded, props) {
+    let Bar = loaded.Bar.default;
+    let i18n = loaded.i18n;
+    return <Bar {...props} i18n={i18n}/>;
+  },
+});
+```
+The `render(loaded, props)` method is passed `loaded` and `props` arguments, and invoked after
+the loader has completed loading.
+
+#### Without a `loading` component
+
+```js
+Loadable.Map({
+  loader: {
+    Bar: () => import('./Bar'),
+    i18n: () => fetch('./i18n/bar.json').then(res => res.json()),
+  },
+  render(state, props) {
+    const { isLoading, loaded } = state;
+    if (isLoading) {
+	  return <div>Loading...</div>;
+	}
+
     let Bar = loaded.Bar.default;
     let i18n = loaded.i18n;
     return <Bar {...props} i18n={i18n}/>;
@@ -349,9 +397,8 @@ Loadable.Map({
 });
 ```
 
-When using `Loadable.Map` the [`render()` method](#optsrender) is required. It
-will be passed a `loaded` param which will be an object matching the shape of
-your `loader`.
+The `render(state, props)` method is passed `state` and `props` arguments, and is invoked
+for every render of the Loadable regardless of the internal loadable state.
 
 ### Preloading
 
@@ -676,13 +723,19 @@ A higher-order component that allows you to load multiple resources in parallel.
 Loadable.Map's [`opts.loader`](#optsloader) accepts an object of functions, and
 needs a [`opts.render`](#optsrender) method.
 
+#### With a `loading` component
+
+When a `loading` prop is defined on Loadable, the `render` method is only invoked
+after the loader import has completed loading.
+
 ```js
 Loadable.Map({
   loader: {
     Bar: () => import('./Bar'),
     i18n: () => fetch('./i18n/bar.json').then(res => res.json()),
   },
-  render({ loaded }, props) {
+  loading: Loading,
+  render(loaded, props) {
     let Bar = loaded.Bar.default;
     let i18n = loaded.i18n;
     return <Bar {...props} i18n={i18n}/>;
@@ -690,8 +743,33 @@ Loadable.Map({
 });
 ```
 
-When using `Loadable.Map` the `render()` method's `loaded` param will be an
-object with the same shape as your `loader`.
+When using `Loadable.Map` the `render()` method's `loaded` param is an object and
+it will have a `loader` prop with the same shape as your `loader`.
+
+#### Without a `loading` component
+
+```js
+Loadable.Map({
+  loader: {
+    Bar: () => import('./Bar'),
+    i18n: () => fetch('./i18n/bar.json').then(res => res.json()),
+  },
+  render(state, props) {
+    const { isLoading, loaded } = state;
+    if (isLoading) {
+	  return <div>Loading...</div>;
+	}
+
+    let Bar = loaded.Bar.default;
+    let i18n = loaded.i18n;
+    return <Bar {...props} i18n={i18n}/>;
+  },
+});
+```
+
+When using `Loadable.Map` the `render(state, props)` method is passed `state` and `props` arguments, and is invoked
+for every render of the Loadable regardless of the internal loadable state.
+
 
 ### `Loadable` and `Loadable.Map` Options
 
@@ -725,17 +803,15 @@ When using with `Loadable.Map` you'll also need to pass a
 A [`LoadingComponent`](#loadingcomponent) that renders while a module is
 loading or when it errors.
 
+The `loading` prop changes the arguments received by the `render` method, this is to maintain backwards compatibility.
+ * When the `loading` prop **is** defined, the first argument received by the `render(loaded, props)` method
+ is the `loaded` that is the resolved value of [`opts.loader`](#optsloader)
+ * When the `loading` props **is not** defined, the first argument received by `render(state, props)` method
+ is the loadable state. You can access the loaded component(s) using `state.loaded`.
+
 ```js
 Loadable({
   loading: LoadingComponent,
-});
-```
-
-This option is required, if you don't want to render anything, return `null`.
-
-```js
-Loadable({
-  loading: () => null,
 });
 ```
 
@@ -769,15 +845,81 @@ Loadable({
 
 #### `opts.render`
 
-A function to customize the rendering of loaded modules.
+A react element or function to customize the rendering of loaded modules.
 
-Receives `loaded` which is the resolved value of [`opts.loader`](#optsloader)
+##### React element with a `loading` component
+
+Receives a `loaded` prop that is the resolved value of [`opts.loader`](#optsloader)
+and `props` which are the props passed to the
+[`LoadableComponent`](#loadablecomponent).
+
+```js
+function CodeSplitRenderer(props) {
+  const { codeSplit, ...componentProps } = props;
+
+  // when used with a 'loading' component, the loaded state is assigned directly to the `codeSplit` prop
+  let Component = codeSplit.default;
+  return <Component {...componentProps}/>;
+}
+
+Loadable({
+  loading: Loading,
+  render: <CodeSplitRenderer />
+});
+```
+
+##### React element without a `loading` component
+
+Receives `state`, with a `loader` prop that is the resolved value of [`opts.loader`](#optsloader)
+and `props` which are the props passed to the
+[`LoadableComponent`](#loadablecomponent).
+
+```js
+function CodeSplitRenderer(props) {
+  const { codeSplit, ...componentProps } = props;
+
+  // when used without a 'loading' component, the loadable state is assigned to the `codeSplit` prop
+  const { isLoading, loaded, pastDelay, timedOut, error } = codeSplit;
+
+  let Component = loaded.default;
+  return <Component {...componentProps}/>;
+}
+
+Loadable({
+  render: <CodeSplitRenderer />
+});
+```
+
+##### Function with a `loading` component
+
+Receives a `loaded` prop that is the resolved value of [`opts.loader`](#optsloader)
 and `props` which are the props passed to the
 [`LoadableComponent`](#loadablecomponent).
 
 ```js
 Loadable({
-  render({ loaded }, props) {
+  loading: Loading,
+  render(loaded, props) {
+    let Component = loaded.default;
+    return <Component {...props}/>;
+  }
+});
+```
+
+##### Function without a `loading` component
+
+Receives `state`, with a `loader` prop that is the resolved value of [`opts.loader`](#optsloader)
+and `props` which are the props passed to the
+[`LoadableComponent`](#loadablecomponent).
+
+```js
+Loadable({
+  render(state, props) {
+    const { isLoading, loaded, pastDelay, timedOut, error } = state;
+    if (isLoading) {
+	  return <div>Loading...</div>;
+	}
+
     let Component = loaded.default;
     return <Component {...props}/>;
   }

--- a/__tests__/__snapshots__/test.js.snap
+++ b/__tests__/__snapshots__/test.js.snap
@@ -28,6 +28,33 @@ exports[`delay and timeout 4`] = `
 </div>
 `;
 
+exports[`loadable map element success without loading prop 1`] = `
+<div>
+  MyLoadingComponent 
+  {"isLoading":true,"pastDelay":false,"timedOut":false,"error":null,"loaded":{}}
+</div>
+`;
+
+exports[`loadable map element success without loading prop 2`] = `
+<div>
+  MyLoadingComponent 
+  {"isLoading":true,"pastDelay":true,"timedOut":false,"error":null,"loaded":{}}
+</div>
+`;
+
+exports[`loadable map element success without loading prop 3`] = `
+<div>
+  <div>
+    MyComponent 
+    {"prop":"baz"}
+  </div>
+  <div>
+    MyComponent 
+    {"prop":"baz"}
+  </div>
+</div>
+`;
+
 exports[`loadable map error 1`] = `
 <div>
   MyLoadingComponent 
@@ -49,6 +76,27 @@ exports[`loadable map error 3`] = `
 </div>
 `;
 
+exports[`loadable map error without loading prop 1`] = `
+<div>
+  MyLoadingComponent 
+  {"isLoading":true,"pastDelay":false,"timedOut":false,"error":null,"loaded":{}}
+</div>
+`;
+
+exports[`loadable map error without loading prop 2`] = `
+<div>
+  MyLoadingComponent 
+  {"isLoading":true,"pastDelay":true,"timedOut":false,"error":null,"loaded":{}}
+</div>
+`;
+
+exports[`loadable map error without loading prop 3`] = `
+<div>
+  MyLoadingComponent 
+  {"isLoading":false,"pastDelay":true,"timedOut":false,"error":{},"loaded":{"a":{}}}
+</div>
+`;
+
 exports[`loadable map success 1`] = `
 <div>
   MyLoadingComponent 
@@ -64,6 +112,33 @@ exports[`loadable map success 2`] = `
 `;
 
 exports[`loadable map success 3`] = `
+<div>
+  <div>
+    MyComponent 
+    {"prop":"baz"}
+  </div>
+  <div>
+    MyComponent 
+    {"prop":"baz"}
+  </div>
+</div>
+`;
+
+exports[`loadable map success without loading prop 1`] = `
+<div>
+  MyLoadingComponent 
+  {"isLoading":true,"pastDelay":false,"timedOut":false,"error":null,"loaded":{}}
+</div>
+`;
+
+exports[`loadable map success without loading prop 2`] = `
+<div>
+  MyLoadingComponent 
+  {"isLoading":true,"pastDelay":true,"timedOut":false,"error":null,"loaded":{}}
+</div>
+`;
+
+exports[`loadable map success without loading prop 3`] = `
 <div>
   <div>
     MyComponent 
@@ -202,21 +277,63 @@ exports[`render 3`] = `
 </div>
 `;
 
-exports[`render loading inline 1`] = `
+exports[`render element 1`] = `
+<div>
+  MyLoadingComponent 
+  {"isLoading":true,"pastDelay":false,"timedOut":false,"error":null}
+</div>
+`;
+
+exports[`render element 2`] = `
+<div>
+  MyLoadingComponent 
+  {"isLoading":true,"pastDelay":true,"timedOut":false,"error":null}
+</div>
+`;
+
+exports[`render element 3`] = `
+<div>
+  MyComponent 
+  {"prop":"baz"}
+</div>
+`;
+
+exports[`render element without loading prop 1`] = `
 <div>
   MyLoadingComponent 
   {"isLoading":true,"pastDelay":false,"timedOut":false,"error":null,"loaded":null}
 </div>
 `;
 
-exports[`render loading inline 2`] = `
+exports[`render element without loading prop 2`] = `
 <div>
   MyLoadingComponent 
   {"isLoading":true,"pastDelay":true,"timedOut":false,"error":null,"loaded":null}
 </div>
 `;
 
-exports[`render loading inline 3`] = `
+exports[`render element without loading prop 3`] = `
+<div>
+  MyComponent 
+  {"prop":"baz"}
+</div>
+`;
+
+exports[`render without loading prop 1`] = `
+<div>
+  MyLoadingComponent 
+  {"isLoading":true,"pastDelay":false,"timedOut":false,"error":null,"loaded":null}
+</div>
+`;
+
+exports[`render without loading prop 2`] = `
+<div>
+  MyLoadingComponent 
+  {"isLoading":true,"pastDelay":true,"timedOut":false,"error":null,"loaded":null}
+</div>
+`;
+
+exports[`render without loading prop 3`] = `
 <div>
   MyComponent 
   {"prop":"baz"}

--- a/__tests__/__snapshots__/test.js.snap
+++ b/__tests__/__snapshots__/test.js.snap
@@ -202,6 +202,27 @@ exports[`render 3`] = `
 </div>
 `;
 
+exports[`render loading inline 1`] = `
+<div>
+  MyLoadingComponent 
+  {"isLoading":true,"pastDelay":false,"timedOut":false,"error":null,"loaded":null}
+</div>
+`;
+
+exports[`render loading inline 2`] = `
+<div>
+  MyLoadingComponent 
+  {"isLoading":true,"pastDelay":true,"timedOut":false,"error":null,"loaded":null}
+</div>
+`;
+
+exports[`render loading inline 3`] = `
+<div>
+  MyComponent 
+  {"prop":"baz"}
+</div>
+`;
+
 exports[`server side rendering 1`] = `
 <div>
   fixture1

--- a/__tests__/test.js
+++ b/__tests__/test.js
@@ -295,4 +295,38 @@ describe('preloadReady', () => {
   
     expect(loadingComponent.toJSON()).toMatchSnapshot(); // loading
   });
+
+  test('getModules', () => {
+    let LoadableMyComponent = Loadable({
+      loader: createLoader(300, () => MyComponent),
+      modules: ['./myModule']
+    });
+    expect(LoadableMyComponent.getModules()).toEqual(['./myModule']);
+  });
+
+  test('getLoader', () => {
+    const componentLoader = createLoader(300, () => MyComponent);
+    let LoadableMyComponent = Loadable({
+      loader: componentLoader
+    });
+    expect(LoadableMyComponent.getLoader()).toBe(componentLoader);
+  });
+
+  test('preload', (done) => {
+    let LoadableMyComponent = Loadable({
+      loader: createLoader(200, () => MyComponent)
+    });
+
+    let LoadableMapComponent = Loadable({
+      loader: {
+        myComponent: createLoader(400, () => MyComponent)
+      }
+    });
+
+    const loaders = [LoadableMyComponent.getLoader(), LoadableMapComponent.getLoader()];
+    Loadable.preload(loaders).then((modules) => {
+      expect(modules).toHaveLength(2);
+      done();
+    });
+  });
 });

--- a/example/components/Example.js
+++ b/example/components/Example.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import Loadable from 'react-loadable';
 import Loading from './Loading';
-import delay from '../utils/delay';
-import path from 'path';
+import PreLoadButton from './PreLoadButton';
 
 const LoadableNested = Loadable({
   loader: () => import('./ExampleNested'),
@@ -14,6 +13,7 @@ export default function Example() {
     <div>
       <h1>Hello from a loadable component</h1>
       <LoadableNested/>
+      <PreLoadButton />
     </div>
   );
 }

--- a/example/components/PreLoadButton.js
+++ b/example/components/PreLoadButton.js
@@ -3,7 +3,7 @@ import Loadable from 'react-loadable';
 import Loading from "./Loading";
 
 const LoadableContent = Loadable({
-    loader: () => import('./PreLoadedContent'),
+    loader: () => import(/* webpackChunkName: "PreLoadedContent" */ './PreLoadedContent'),
     loading: Loading,
 });
 

--- a/example/components/PreLoadButton.js
+++ b/example/components/PreLoadButton.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import Loadable from 'react-loadable';
+import Loading from "./Loading";
+
+const LoadableContent = Loadable({
+    loader: () => import('./PreLoadedContent'),
+    loading: Loading,
+});
+
+// NOTE: This is for demo purposes only.
+//       Pre-loading a single module is no different than using a standard loadable
+export default class PreLoadButton extends React.Component {
+  state = {
+    isLoaded: false
+  };
+
+  preloadModules() {
+    if (this.state.isLoaded) {
+      return;
+    }
+
+    // Verify webpack only submits a single request
+    Loadable.preload([
+      LoadableContent.getLoader(),
+      LoadableContent.getLoader(),
+      LoadableContent.getLoader()
+    ]).then(() => {
+      console.log('pre-loading modules');
+      this.setState({ isLoaded: true });
+    });
+  }
+
+  render() {
+    const { isLoaded } = this.state;
+    console.log('is content pre-loaded? ' + isLoaded);
+    return (
+      <div>
+        <button onClick={() => this.preloadModules()}>Preload Modules</button>
+        {isLoaded && <LoadableContent />}
+      </div>
+    );
+  }
+}

--- a/example/components/PreLoadedContent.js
+++ b/example/components/PreLoadedContent.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function PreLoadedContent() {
+  return <p>This content was pre-loaded!</p>;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -104,7 +104,7 @@ function createLoadableComponent(loadFn, options) {
     timeout: null,
     render: defaultRender,
     webpack: null,
-    modules: null,
+    modules: [],
   }, options);
 
   let res = null;
@@ -148,6 +148,14 @@ function createLoadableComponent(loadFn, options) {
 
     static preload() {
       return init();
+    }
+
+    static getModules() {
+      return opts.modules;
+    }
+
+    static getLoader() {
+      return opts.loader;
     }
 
     componentWillMount() {
@@ -296,6 +304,24 @@ Loadable.preloadReady = () => {
   return new Promise((resolve, reject) => {
     // We always will resolve, errors should be handled within loading UIs.
     flushInitializers(READY_INITIALIZERS).then(resolve, resolve);
+  });
+};
+
+Loadable.preload = (loaders) => {
+  return new Promise((resolve, reject) => {
+    const allLoaders = loaders.reduce((acc, loader) => {
+      if (typeof loader === 'function') {
+        acc.push(loader);
+      }
+      else if (typeof loader === 'object' && !Array.isArray(loader) && loader !== null) {
+        Object.keys(loader).forEach(mapKey => acc.push(loader[mapKey]));
+      }
+
+      return acc;
+    }, []);
+
+    // reject on error - manually handler error scenarios for manual preload
+    return Promise.all(allLoaders).then(resolve, reject);
   });
 };
 

--- a/src/webpack.js
+++ b/src/webpack.js
@@ -8,23 +8,25 @@ function buildManifest(compiler, compilation) {
   let manifest = {};
 
   compilation.chunks.forEach(chunk => {
-    chunk.files.forEach(file => {
-      chunk.forEachModule(module => {
-        let id = module.id;
-        let name = typeof module.libIdent === 'function' ? module.libIdent({ context }) : null;
-        let publicPath = url.resolve(compilation.outputOptions.publicPath || '', file);
-        
-        let currentModule = module;
-        if (module.constructor.name === 'ConcatenatedModule') {
-          currentModule = module.rootModule;
-        }
-        if (!manifest[currentModule.rawRequest]) {
-          manifest[currentModule.rawRequest] = [];
-        }
+    if (chunk.name !== 'main') {
+      chunk.files.forEach(file => {
+        chunk.forEachModule(module => {
+          let id = module.id;
+          let name = typeof module.libIdent === 'function' ? module.libIdent({ context }) : null;
+          let publicPath = url.resolve(compilation.outputOptions.publicPath || '', file);
 
-        manifest[currentModule.rawRequest].push({ id, name, file, publicPath });
+          let currentModule = module;
+          if (module.constructor.name === 'ConcatenatedModule') {
+            currentModule = module.rootModule;
+          }
+          if (!manifest[currentModule.rawRequest]) {
+            manifest[currentModule.rawRequest] = [];
+          }
+
+          manifest[currentModule.rawRequest].push({ id, name, file, publicPath });
+        });
       });
-    });
+    }
   });
 
   return manifest;

--- a/src/webpack.js
+++ b/src/webpack.js
@@ -3,12 +3,23 @@ const fs = require('fs');
 const path = require('path');
 const url = require('url');
 
-function buildManifest(compiler, compilation) {
+function buildManifest(compiler, compilation, ignoreChunkNames) {
   let context = compiler.options.context;
   let manifest = {};
 
   compilation.chunks.forEach(chunk => {
-    if (chunk.name !== 'main') {
+    // Determine if the chunk should be ignored
+    const chunkName = typeof chunk.name === 'undefined' ? 'undefined' : chunk.name === null ? 'null' : chunk.name;
+    const ignoreChunk = ignoreChunkNames.length === 0 ? false : ignoreChunkNames.some(chunkNameCondition => {
+      if (chunkNameCondition instanceof RegExp) {
+        chunkNameCondition.lastIndex = 0; // reset in-case its a global regexp
+        return chunkNameCondition.test(chunkName);
+      }
+
+      return chunkNameCondition === chunkName;
+    });
+
+    if (!ignoreChunk) {
       chunk.files.forEach(file => {
         chunk.forEachModule(module => {
           let id = module.id;
@@ -35,11 +46,13 @@ function buildManifest(compiler, compilation) {
 class ReactLoadablePlugin {
   constructor(opts = {}) {
     this.filename = opts.filename;
+    const ignoreChunkNames = opts.ignoreChunkNames || [];
+    this.ignoreChunkNames = Array.isArray(ignoreChunkNames) ? ignoreChunkNames : [ignoreChunkNames];
   }
 
   apply(compiler) {
     compiler.plugin('emit', (compilation, callback) => {
-      const manifest = buildManifest(compiler, compilation);
+      const manifest = buildManifest(compiler, compilation, this.ignoreChunkNames);
       var json = JSON.stringify(manifest, null, 2);
       const outputDirectory = path.dirname(this.filename);
       try {


### PR DESCRIPTION
@jamiebuilds, thanks for the great work.

I have a use-case not currently supported by `react-loadable`; to block rendering of deeply nested routes that use dynamically loaded components until all those components are loaded.

This PR enables `react-loadable` to be used for the above use-case. I've made a few small modifications to improve the ability to fully control the render lifecycle of dynamically loaded components. 

1. For custom render methods without a `loading` prop, pass `state` instead of `loaded` (Also fixes #99)
2. Allow developers to manually preload modules on the client
3. `render` also accepts react elements

Note: with these changes the `loading` prop becomes _optional_ as it is now possible to render custom loading content using the `render()` method.

I've commented each of the commits in the pull request, but I'll repeat those here for a quick summary.

#### Commit 1
When a `loading` prop is defined on a `Loadable`, the behavior remains backwards compatible. When **no** `loading` prop is defined, the `render(state, props)` method receives a loadable `state` argument instead of `loaded` argument.
~~Instead of only passing `loaded` to custom `render()`, pass _state_ to give full control when rendering the dynamically loaded component(s).~~ This allows easily implementing behaviors such as transitions, and blocking of nested route rendering until all modules are loaded.

This is ~~_almost_~~ entirely backwards compatible. ~~The **only** change required by users of previous versions is to use `object destructuring` syntax for the “loaded” argument. This can be done with a simple find & replace.~~

~~Example: `render(loaded, props)` must change to `render({ loaded }, props)`~~

#### Commit 2
Allows developers to manually preload webpack modules.

**use-case**: _preloading all modules required by a deeply nested route_
When dynamically loading a deeply nested route (many levels deep), you can provide a better user experience when all required modules are loaded before rendering the route for the user.
 * This prevents waterfall rendering of nested components (where a user can see parent components render before child components).
 * Allows developers to easily handle errors and display an error page if the route fails to load, rather than having to display error messages for each component/module that failed to load

Example:
```js
import Loadable from 'react-loadable';

const LoadableContent = Loadable({
    loader: () => import('./PreLoadedContent')
});

// Use loadable to manually preload modules using 'loaders'
Loadable.preload([LoadableContent.getLoader()]).then(() => {
  this.setState({ isLoaded: true });
});

```
See the updated example in the PR for a better example.

#### Commit 4
The `render` property can also  accept a react element for rendering the loadable.
```js
function CodeSplitRenderer(props) {
  const { codeSplit, ...rest } = props;
  return <codeSplit.loaded {...rest} />;
}

const myLoadable = Loadable({
  render: <CodeSplitRenderer myProp="someValue" />
});
```

Let me know what you think, ~~I know the breaking change isn't ideal but its small and easy to fix for developers~~. I think these changes allow `react-loadable` to be used for a very common use-case for which there are many less-elegant custom solutions blogged about.