### PR TITLE
Inject props to `loading` component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -215,7 +215,8 @@ function createLoadableComponent(loadFn, options) {
           isLoading: this.state.loading,
           pastDelay: this.state.pastDelay,
           timedOut: this.state.timedOut,
-          error: this.state.error
+          error: this.state.error,
+          ...this.props
         });
       } else if (this.state.loaded) {
         return opts.render(this.state.loaded, this.props);


### PR DESCRIPTION
To be able to affect the loading indication with more context.

For us, this would help because we already have a loading indicator for our XHR request, and this loading indicator is wrapping the feature that is being code split. So without this, there would be two loading indicators visible/used.

With this change, we can inject our own loading state into Loadable when needed.

// @ehellman & @danielwerthen