### PR TITLE
Update version to 5.3.2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-loadable",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "description": "A higher order component for loading components with promises",
   "main": "lib/index.js",
   "author": "James Kyle <me@thejameskyle.com>",


### PR DESCRIPTION
There have been quite a few changes since the last bump in version, most notably https://github.com/jamiebuilds/react-loadable/commit/60495e387c11e97a11a3087402afa589d822c0fc which exposes the `publicPath` from the Webpack config.

I just want an updated version so I can use that feature, but I couldn't file an Issue.