### PR TITLE
Allow default options & loader fn to be passed straight to Loadable

### DIFF
--- a/__tests__/__snapshots__/test.js.snap
+++ b/__tests__/__snapshots__/test.js.snap
@@ -97,28 +97,56 @@ exports[`loading error 3`] = `
 </div>
 `;
 
-exports[`loading success 1`] = `
+exports[`loading success default options.loading, fn arg 1`] = `
 <div>
   MyLoadingComponent 
   {"isLoading":true,"pastDelay":false,"timedOut":false,"error":null}
 </div>
 `;
 
-exports[`loading success 2`] = `
+exports[`loading success default options.loading, fn arg 2`] = `
 <div>
   MyLoadingComponent 
   {"isLoading":true,"pastDelay":true,"timedOut":false,"error":null}
 </div>
 `;
 
-exports[`loading success 3`] = `
+exports[`loading success default options.loading, fn arg 3`] = `
 <div>
   MyComponent 
   {"prop":"foo"}
 </div>
 `;
 
-exports[`loading success 4`] = `
+exports[`loading success default options.loading, fn arg 4`] = `
+<div>
+  MyComponent 
+  {"prop":"bar"}
+</div>
+`;
+
+exports[`loading success no defaults, object arg 1`] = `
+<div>
+  MyLoadingComponent 
+  {"isLoading":true,"pastDelay":false,"timedOut":false,"error":null}
+</div>
+`;
+
+exports[`loading success no defaults, object arg 2`] = `
+<div>
+  MyLoadingComponent 
+  {"isLoading":true,"pastDelay":true,"timedOut":false,"error":null}
+</div>
+`;
+
+exports[`loading success no defaults, object arg 3`] = `
+<div>
+  MyComponent 
+  {"prop":"foo"}
+</div>
+`;
+
+exports[`loading success no defaults, object arg 4`] = `
 <div>
   MyComponent 
   {"prop":"bar"}

--- a/__tests__/test.js
+++ b/__tests__/test.js
@@ -37,24 +37,51 @@ afterEach(async () => {
   } catch (err) {}
 });
 
-test('loading success', async () => {
-  let LoadableMyComponent = Loadable({
-    loader: createLoader(400, () => MyComponent),
-    loading: MyLoadingComponent
+describe('loading success', async () => {
+  afterAll(() => {
+    Loadable.setDefaultOptions({})
+  })
+
+  test('no defaults, object arg', async () => {
+    let LoadableMyComponent = Loadable({
+      loader: createLoader(400, () => MyComponent),
+      loading: MyLoadingComponent
+    });
+
+    let component1 = renderer.create(<LoadableMyComponent prop="foo" />);
+
+    expect(component1.toJSON()).toMatchSnapshot(); // initial
+    await waitFor(200);
+    expect(component1.toJSON()).toMatchSnapshot(); // loading
+    await waitFor(200);
+    expect(component1.toJSON()).toMatchSnapshot(); // loaded
+
+    let component2 = renderer.create(<LoadableMyComponent prop="bar" />);
+
+    expect(component2.toJSON()).toMatchSnapshot(); // reload
   });
 
-  let component1 = renderer.create(<LoadableMyComponent prop="foo" />);
+  test('default options.loading, fn arg', async () => {
+    Loadable.setDefaultOptions({
+      loading: MyLoadingComponent
+    });
 
-  expect(component1.toJSON()).toMatchSnapshot(); // initial
-  await waitFor(200);
-  expect(component1.toJSON()).toMatchSnapshot(); // loading
-  await waitFor(200);
-  expect(component1.toJSON()).toMatchSnapshot(); // loaded
+    // pass what would be `options.loader`
+    let LoadableMyComponent = Loadable(createLoader(400, () => MyComponent));
 
-  let component2 = renderer.create(<LoadableMyComponent prop="bar" />);
+    let component1 = renderer.create(<LoadableMyComponent prop="foo" />);
 
-  expect(component2.toJSON()).toMatchSnapshot(); // reload
-});
+    expect(component1.toJSON()).toMatchSnapshot(); // initial
+    await waitFor(200);
+    expect(component1.toJSON()).toMatchSnapshot(); // loading
+    await waitFor(200);
+    expect(component1.toJSON()).toMatchSnapshot(); // loaded
+
+    let component2 = renderer.create(<LoadableMyComponent prop="bar" />);
+
+    expect(component2.toJSON()).toMatchSnapshot(); // reload
+  });
+})
 
 test('delay and timeout', async () => {
   let LoadableMyComponent = Loadable({

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,8 @@ const PropTypes = require('prop-types');
 const ALL_INITIALIZERS = [];
 const READY_INITIALIZERS = [];
 
+let optionDefaults = {};
+
 function isWebpackReady(getModuleIds) {
   if (typeof __webpack_modules__ !== 'object') {
     return false;
@@ -92,7 +94,13 @@ function render(loaded, props) {
 }
 
 function createLoadableComponent(loadFn, options) {
-  if (!options.loading) {
+  if (typeof options === 'function') {
+    options = {
+      loader: options
+    }
+  }
+
+  if (!options.loading && !optionDefaults.loading) {
     throw new Error('react-loadable requires a `loading` component')
   }
 
@@ -104,7 +112,7 @@ function createLoadableComponent(loadFn, options) {
     render: render,
     webpack: null,
     modules: null,
-  }, options);
+  }, optionDefaults, options);
 
   let res = null;
 
@@ -293,5 +301,12 @@ Loadable.preloadReady = () => {
     flushInitializers(READY_INITIALIZERS).then(resolve, resolve);
   });
 };
+
+Loadable.setDefaultOptions = (options) => {
+  if (typeof options !== 'object' || options === null) {
+    throw new Error('Loadable.setDefaultOptions expects an object')
+  }
+  optionDefaults = options
+}
 
 module.exports = Loadable;


### PR DESCRIPTION
It gets a bit verbose if you have lots of `Loadable`s that only have `options{loader,loading}` where each share the same `loading` component.

This PR would allow the following...

```
// BEFORE
const Start = Loadable({
  loading: Loading,
  loader: () => import('../Home')
})

const User = Loadable({
  loading: Loading,
  loader: () => import('../User')
})

const Feed = Loadable({
  loading: Loading,
  loader: () => import('../Feed')
})

```

```
// AFTER
Loadable.setDefaultOptions({
  loading: Loading
})

const Start = Loadable(() => import('../Home'))
const User = Loadable(() => import('../User'))
const Feed = Loadable(() => import('../Feed'))
```

Just a suggestion in the form of a PR, as issues aren't open.

The README would need updating, which I will do if this functionality is desirable.

Thanks for a great lib!