### PR TITLE
pass in given props to loading component

### DIFF
--- a/__tests__/__snapshots__/test.js.snap
+++ b/__tests__/__snapshots__/test.js.snap
@@ -3,21 +3,21 @@
 exports[`delay and timeout 1`] = `
 <div>
   MyLoadingComponent 
-  {"isLoading":true,"pastDelay":false,"timedOut":false,"error":null}
+  {"isLoading":true,"pastDelay":false,"timedOut":false,"error":null,"prop":"foo"}
 </div>
 `;
 
 exports[`delay and timeout 2`] = `
 <div>
   MyLoadingComponent 
-  {"isLoading":true,"pastDelay":true,"timedOut":false,"error":null}
+  {"isLoading":true,"pastDelay":true,"timedOut":false,"error":null,"prop":"foo"}
 </div>
 `;
 
 exports[`delay and timeout 3`] = `
 <div>
   MyLoadingComponent 
-  {"isLoading":true,"pastDelay":true,"timedOut":true,"error":null}
+  {"isLoading":true,"pastDelay":true,"timedOut":true,"error":null,"prop":"foo"}
 </div>
 `;
 
@@ -31,35 +31,35 @@ exports[`delay and timeout 4`] = `
 exports[`loadable map error 1`] = `
 <div>
   MyLoadingComponent 
-  {"isLoading":true,"pastDelay":false,"timedOut":false,"error":null}
+  {"isLoading":true,"pastDelay":false,"timedOut":false,"error":null,"prop":"baz"}
 </div>
 `;
 
 exports[`loadable map error 2`] = `
 <div>
   MyLoadingComponent 
-  {"isLoading":true,"pastDelay":true,"timedOut":false,"error":null}
+  {"isLoading":true,"pastDelay":true,"timedOut":false,"error":null,"prop":"baz"}
 </div>
 `;
 
 exports[`loadable map error 3`] = `
 <div>
   MyLoadingComponent 
-  {"isLoading":false,"pastDelay":true,"timedOut":false,"error":{}}
+  {"isLoading":false,"pastDelay":true,"timedOut":false,"error":{},"prop":"baz"}
 </div>
 `;
 
 exports[`loadable map success 1`] = `
 <div>
   MyLoadingComponent 
-  {"isLoading":true,"pastDelay":false,"timedOut":false,"error":null}
+  {"isLoading":true,"pastDelay":false,"timedOut":false,"error":null,"prop":"baz"}
 </div>
 `;
 
 exports[`loadable map success 2`] = `
 <div>
   MyLoadingComponent 
-  {"isLoading":true,"pastDelay":true,"timedOut":false,"error":null}
+  {"isLoading":true,"pastDelay":true,"timedOut":false,"error":null,"prop":"baz"}
 </div>
 `;
 
@@ -79,35 +79,35 @@ exports[`loadable map success 3`] = `
 exports[`loading error 1`] = `
 <div>
   MyLoadingComponent 
-  {"isLoading":true,"pastDelay":false,"timedOut":false,"error":null}
+  {"isLoading":true,"pastDelay":false,"timedOut":false,"error":null,"prop":"baz"}
 </div>
 `;
 
 exports[`loading error 2`] = `
 <div>
   MyLoadingComponent 
-  {"isLoading":true,"pastDelay":true,"timedOut":false,"error":null}
+  {"isLoading":true,"pastDelay":true,"timedOut":false,"error":null,"prop":"baz"}
 </div>
 `;
 
 exports[`loading error 3`] = `
 <div>
   MyLoadingComponent 
-  {"isLoading":false,"pastDelay":true,"timedOut":false,"error":{}}
+  {"isLoading":false,"pastDelay":true,"timedOut":false,"error":{},"prop":"baz"}
 </div>
 `;
 
 exports[`loading success 1`] = `
 <div>
   MyLoadingComponent 
-  {"isLoading":true,"pastDelay":false,"timedOut":false,"error":null}
+  {"isLoading":true,"pastDelay":false,"timedOut":false,"error":null,"prop":"foo"}
 </div>
 `;
 
 exports[`loading success 2`] = `
 <div>
   MyLoadingComponent 
-  {"isLoading":true,"pastDelay":true,"timedOut":false,"error":null}
+  {"isLoading":true,"pastDelay":true,"timedOut":false,"error":null,"prop":"foo"}
 </div>
 `;
 
@@ -128,7 +128,7 @@ exports[`loading success 4`] = `
 exports[`preload 1`] = `
 <div>
   MyLoadingComponent 
-  {"isLoading":true,"pastDelay":false,"timedOut":false,"error":null}
+  {"isLoading":true,"pastDelay":false,"timedOut":false,"error":null,"prop":"baz"}
 </div>
 `;
 
@@ -149,7 +149,7 @@ exports[`preload 3`] = `
 exports[`preloadReady delay with 0 1`] = `
 <div>
   MyLoadingComponent 
-  {"isLoading":true,"pastDelay":true,"timedOut":false,"error":null}
+  {"isLoading":true,"pastDelay":true,"timedOut":false,"error":null,"prop":"foo"}
 </div>
 `;
 
@@ -163,7 +163,7 @@ exports[`preloadReady many 1`] = `
 exports[`preloadReady missing 1`] = `
 <div>
   MyLoadingComponent 
-  {"isLoading":true,"pastDelay":false,"timedOut":false,"error":null}
+  {"isLoading":true,"pastDelay":false,"timedOut":false,"error":null,"prop":"baz"}
 </div>
 `;
 
@@ -177,21 +177,21 @@ exports[`preloadReady one 1`] = `
 exports[`preloadReady undefined 1`] = `
 <div>
   MyLoadingComponent 
-  {"isLoading":true,"pastDelay":false,"timedOut":false,"error":null}
+  {"isLoading":true,"pastDelay":false,"timedOut":false,"error":null,"prop":"baz"}
 </div>
 `;
 
 exports[`render 1`] = `
 <div>
   MyLoadingComponent 
-  {"isLoading":true,"pastDelay":false,"timedOut":false,"error":null}
+  {"isLoading":true,"pastDelay":false,"timedOut":false,"error":null,"prop":"baz"}
 </div>
 `;
 
 exports[`render 2`] = `
 <div>
   MyLoadingComponent 
-  {"isLoading":true,"pastDelay":true,"timedOut":false,"error":null}
+  {"isLoading":true,"pastDelay":true,"timedOut":false,"error":null,"prop":"baz"}
 </div>
 `;
 

--- a/src/index.js
+++ b/src/index.js
@@ -211,12 +211,12 @@ function createLoadableComponent(loadFn, options) {
 
     render() {
       if (this.state.loading || this.state.error) {
-        return React.createElement(opts.loading, {
+        return React.createElement(opts.loading, Object.assign({
           isLoading: this.state.loading,
           pastDelay: this.state.pastDelay,
           timedOut: this.state.timedOut,
           error: this.state.error
-        });
+        }, this.props));
       } else if (this.state.loaded) {
         return opts.render(this.state.loaded, this.props);
       } else {


### PR DESCRIPTION
First of all, thanks for this package!

Now about the PR.. we want to be able to have a loading component that doesn't look like one.. for example, when loading:

- autocomplete or datepicker field can be displayed as a normal textfield 
- custom select box can be displayed as either a normal select or a button (depending on your design)
- element which display modal, tooltip or other type of popper on click/hover can be rendered with no interaction
- lower quality image while the original image is loading

to achieve this, we need to have access to the original given props when rendering the loading component, so that we can apply the `className` or read any `value` as required..