### PR TITLE
Fix error prop type dox

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ couple different props.
 
 When your [`loader`](optsloader) fails, your [loading component](#loadingcomponent)
 will receive an [`error`](propserror) prop which will be `true` (otherwise it
-will be `false`).
+will be an `Error` object).
 
 ```js
 function Loading(props) {

--- a/README.md
+++ b/README.md
@@ -219,8 +219,8 @@ couple different props.
 #### Loading error states
 
 When your [`loader`](optsloader) fails, your [loading component](#loadingcomponent)
-will receive an [`error`](propserror) prop which will be `true` (otherwise it
-will be an `Error` object).
+will receive an [`error`](propserror) prop which will be an `Error` object (otherwise it
+will be `false`).
 
 ```js
 function Loading(props) {


### PR DESCRIPTION
When an error occurs, the error object is passed (not `true`).