### PR TITLE
Add a preloadables preloader, which skips webpack checks for meteor, …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .idea
 node_modules
 *.log
-lib
 coverage
 example/dist

--- a/lib/babel.js
+++ b/lib/babel.js
@@ -1,0 +1,73 @@
+'use strict';
+
+exports.__esModule = true;
+
+exports.default = function (_ref) {
+  var t = _ref.types,
+      template = _ref.template;
+
+  return {
+    visitor: {
+      ImportDeclaration: function ImportDeclaration(path) {
+        var source = path.node.source.value;
+        if (source !== 'react-loadable') return;
+
+        var defaultSpecifier = path.get('specifiers').find(function (specifier) {
+          return specifier.isImportDefaultSpecifier();
+        });
+
+        if (!defaultSpecifier) return;
+
+        var bindingName = defaultSpecifier.node.local.name;
+        var binding = path.scope.getBinding(bindingName);
+
+        binding.referencePaths.forEach(function (refPath) {
+          var callExpression = refPath.parentPath;
+
+          if (callExpression.isMemberExpression() && callExpression.node.computed === false && callExpression.get('property').isIdentifier({ name: 'Map' })) {
+            callExpression = callExpression.parentPath;
+          }
+
+          if (!callExpression.isCallExpression()) return;
+
+          var args = callExpression.get('arguments');
+          if (args.length !== 1) throw callExpression.error;
+
+          var options = args[0];
+          if (!options.isObjectExpression()) return;
+
+          var properties = options.get('properties');
+          var propertiesMap = {};
+
+          properties.forEach(function (property) {
+            var key = property.get('key');
+            propertiesMap[key.node.name] = property;
+          });
+
+          if (propertiesMap.webpack) {
+            return;
+          }
+
+          var loaderMethod = propertiesMap.loader.get('value');
+          var dynamicImports = [];
+
+          loaderMethod.traverse({
+            Import: function Import(path) {
+              dynamicImports.push(path.parentPath);
+            }
+          });
+
+          if (!dynamicImports.length) return;
+
+          propertiesMap.loader.insertAfter(t.objectProperty(t.identifier('webpack'), t.arrowFunctionExpression([], t.arrayExpression(dynamicImports.map(function (dynamicImport) {
+            return t.callExpression(t.memberExpression(t.identifier('require'), t.identifier('resolve')), [dynamicImport.get('arguments')[0].node]);
+          })))));
+
+          propertiesMap.loader.insertAfter(t.objectProperty(t.identifier('modules'), t.arrayExpression(dynamicImports.map(function (dynamicImport) {
+            return dynamicImport.get('arguments')[0].node;
+          }))));
+        });
+      }
+    }
+  };
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,342 @@
+'use strict';
+
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var React = require('react');
+var PropTypes = require('prop-types');
+
+var ALL_INITIALIZERS = [];
+var READY_INITIALIZERS = [];
+var INITIALIZERS_BY_WEBPACK = {};
+
+function isWebpackReady(getModuleIds) {
+  if ((typeof __webpack_modules__ === 'undefined' ? 'undefined' : _typeof(__webpack_modules__)) !== 'object') {
+    return false;
+  }
+
+  return getModuleIds().every(function (moduleId) {
+    return typeof moduleId !== 'undefined' && typeof __webpack_modules__[moduleId] !== 'undefined';
+  });
+}
+
+function load(loader) {
+  var promise = loader();
+
+  var state = {
+    loading: true,
+    loaded: null,
+    error: null
+  };
+
+  state.promise = promise.then(function (loaded) {
+    state.loading = false;
+    state.loaded = loaded;
+    return loaded;
+  }).catch(function (err) {
+    state.loading = false;
+    state.error = err;
+    throw err;
+  });
+
+  return state;
+}
+
+function loadMap(obj) {
+  var state = {
+    loading: false,
+    loaded: {},
+    error: null
+  };
+
+  var promises = [];
+
+  try {
+    Object.keys(obj).forEach(function (key) {
+      var result = load(obj[key]);
+
+      if (!result.loading) {
+        state.loaded[key] = result.loaded;
+        state.error = result.error;
+      } else {
+        state.loading = true;
+      }
+
+      promises.push(result.promise);
+
+      result.promise.then(function (res) {
+        state.loaded[key] = res;
+      }).catch(function (err) {
+        state.error = err;
+      });
+    });
+  } catch (err) {
+    state.error = err;
+  }
+
+  state.promise = Promise.all(promises).then(function (res) {
+    state.loading = false;
+    return res;
+  }).catch(function (err) {
+    state.loading = false;
+    throw err;
+  });
+
+  return state;
+}
+
+function resolve(obj) {
+  return obj && obj.__esModule ? obj.default : obj;
+}
+
+function render(loaded, props) {
+  return React.createElement(resolve(loaded), props);
+}
+
+function createLoadableComponent(loadFn, options) {
+  var _class, _temp;
+
+  if (!options.loading) {
+    throw new Error('react-loadable requires a `loading` component');
+  }
+
+  var opts = Object.assign({
+    loader: null,
+    loading: null,
+    delay: 200,
+    timeout: null,
+    render: render,
+    webpack: null,
+    modules: null
+  }, options);
+
+  var res = null;
+
+  function init() {
+    if (!res) {
+      res = loadFn(opts.loader);
+    }
+    return res.promise;
+  }
+
+  ALL_INITIALIZERS.push(init);
+
+  if (typeof opts.webpack === 'function') {
+    READY_INITIALIZERS.push(function () {
+      if (isWebpackReady(opts.webpack)) {
+        return init();
+      }
+    });
+    INITIALIZERS_BY_WEBPACK[opts.webpack().sort().join(',')] = function () {
+      return init();
+    };
+  }
+
+  return _temp = _class = function (_React$Component) {
+    _inherits(LoadableComponent, _React$Component);
+
+    function LoadableComponent(props) {
+      _classCallCheck(this, LoadableComponent);
+
+      var _this = _possibleConstructorReturn(this, _React$Component.call(this, props));
+
+      init();
+
+      _this.state = {
+        error: res.error,
+        pastDelay: false,
+        timedOut: false,
+        loading: res.loading,
+        loaded: res.loaded
+      };
+      return _this;
+    }
+
+    LoadableComponent.preload = function preload() {
+      return init();
+    };
+
+    LoadableComponent.prototype.componentWillMount = function componentWillMount() {
+      var _this2 = this;
+
+      this._mounted = true;
+
+      if (this.context.loadable && Array.isArray(opts.modules)) {
+        opts.modules.forEach(function (moduleName) {
+          _this2.context.loadable.report(moduleName);
+        });
+      }
+
+      if (this.context.loadable && typeof this.context.loadable.reportResolved === 'function' && typeof opts.webpack === 'function') {
+        this.context.loadable.reportResolved(opts.webpack());
+      }
+
+      if (!res.loading) {
+        return;
+      }
+
+      if (typeof opts.delay === 'number') {
+        if (opts.delay === 0) {
+          this.setState({ pastDelay: true });
+        } else {
+          this._delay = setTimeout(function () {
+            _this2.setState({ pastDelay: true });
+          }, opts.delay);
+        }
+      }
+
+      if (typeof opts.timeout === 'number') {
+        this._timeout = setTimeout(function () {
+          _this2.setState({ timedOut: true });
+        }, opts.timeout);
+      }
+
+      var update = function update() {
+        if (!_this2._mounted) {
+          return;
+        }
+
+        _this2.setState({
+          error: res.error,
+          loaded: res.loaded,
+          loading: res.loading
+        });
+
+        _this2._clearTimeouts();
+      };
+
+      res.promise.then(function () {
+        update();
+      }).catch(function (err) {
+        update();
+      });
+    };
+
+    LoadableComponent.prototype.componentWillUnmount = function componentWillUnmount() {
+      this._mounted = false;
+      this._clearTimeouts();
+    };
+
+    LoadableComponent.prototype._clearTimeouts = function _clearTimeouts() {
+      clearTimeout(this._delay);
+      clearTimeout(this._timeout);
+    };
+
+    LoadableComponent.prototype.render = function render() {
+      if (this.state.loading || this.state.error) {
+        return React.createElement(opts.loading, {
+          isLoading: this.state.loading,
+          pastDelay: this.state.pastDelay,
+          timedOut: this.state.timedOut,
+          error: this.state.error
+        });
+      } else if (this.state.loaded) {
+        return opts.render(this.state.loaded, this.props);
+      } else {
+        return null;
+      }
+    };
+
+    return LoadableComponent;
+  }(React.Component), _class.contextTypes = {
+    loadable: PropTypes.shape({
+      report: PropTypes.func.isRequired,
+      reportResolved: PropTypes.func
+    })
+  }, _temp;
+}
+
+function Loadable(opts) {
+  return createLoadableComponent(load, opts);
+}
+
+function LoadableMap(opts) {
+  if (typeof opts.render !== 'function') {
+    throw new Error('LoadableMap requires a `render(loaded, props)` function');
+  }
+
+  return createLoadableComponent(loadMap, opts);
+}
+
+Loadable.Map = LoadableMap;
+
+var Capture = function (_React$Component2) {
+  _inherits(Capture, _React$Component2);
+
+  function Capture() {
+    _classCallCheck(this, Capture);
+
+    return _possibleConstructorReturn(this, _React$Component2.apply(this, arguments));
+  }
+
+  Capture.prototype.getChildContext = function getChildContext() {
+    return {
+      loadable: {
+        report: this.props.report,
+        reportResolved: this.props.reportResolved
+      }
+    };
+  };
+
+  Capture.prototype.render = function render() {
+    return React.Children.only(this.props.children);
+  };
+
+  return Capture;
+}(React.Component);
+
+Capture.propTypes = {
+  report: PropTypes.func.isRequired,
+  reportResolved: PropTypes.func
+};
+Capture.childContextTypes = {
+  loadable: PropTypes.shape({
+    report: PropTypes.func.isRequired,
+    reportResolved: PropTypes.func
+  }).isRequired
+};
+
+
+Loadable.Capture = Capture;
+
+function flushInitializers(initializers) {
+  var promises = [];
+
+  while (initializers.length) {
+    var init = initializers.pop();
+    promises.push(init());
+  }
+
+  return Promise.all(promises).then(function () {
+    if (initializers.length) {
+      return flushInitializers(initializers);
+    }
+  });
+}
+
+Loadable.preloadAll = function () {
+  return new Promise(function (resolve, reject) {
+    flushInitializers(ALL_INITIALIZERS).then(resolve, reject);
+  });
+};
+
+Loadable.preloadReady = function () {
+  return new Promise(function (resolve, reject) {
+    // We always will resolve, errors should be handled within loading UIs.
+    flushInitializers(READY_INITIALIZERS).then(resolve, resolve);
+  });
+};
+
+Loadable.preloadablesReady = function (preloadables) {
+  var initializers = preloadables.map(function (preloadable) {
+    return INITIALIZERS_BY_WEBPACK[preloadable.sort().join(',')];
+  });
+  return flushInitializers(initializers);
+};
+
+module.exports = Loadable;

--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -1,0 +1,74 @@
+'use strict';
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var fs = require('fs');
+var path = require('path');
+var url = require('url');
+
+function buildManifest(compiler, compilation) {
+  var context = compiler.options.context;
+  var manifest = {};
+
+  compilation.chunks.forEach(function (chunk) {
+    chunk.files.forEach(function (file) {
+      chunk.forEachModule(function (module) {
+        var id = module.id;
+        var name = typeof module.libIdent === 'function' ? module.libIdent({ context: context }) : null;
+        var publicPath = url.resolve(compilation.outputOptions.publicPath || '', file);
+
+        var currentModule = module;
+        if (module.constructor.name === 'ConcatenatedModule') {
+          currentModule = module.rootModule;
+        }
+        if (!manifest[currentModule.rawRequest]) {
+          manifest[currentModule.rawRequest] = [];
+        }
+
+        manifest[currentModule.rawRequest].push({ id: id, name: name, file: file, publicPath: publicPath });
+      });
+    });
+  });
+
+  return manifest;
+}
+
+var ReactLoadablePlugin = function () {
+  function ReactLoadablePlugin() {
+    var opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+
+    _classCallCheck(this, ReactLoadablePlugin);
+
+    this.filename = opts.filename;
+  }
+
+  ReactLoadablePlugin.prototype.apply = function apply(compiler) {
+    var _this = this;
+
+    compiler.plugin('emit', function (compilation, callback) {
+      var manifest = buildManifest(compiler, compilation);
+      var json = JSON.stringify(manifest, null, 2);
+      var outputDirectory = path.dirname(_this.filename);
+      try {
+        fs.mkdirSync(outputDirectory);
+      } catch (err) {
+        if (err.code !== 'EEXIST') {
+          throw err;
+        }
+      }
+      fs.writeFileSync(_this.filename, json);
+      callback();
+    });
+  };
+
+  return ReactLoadablePlugin;
+}();
+
+function getBundles(manifest, moduleIds) {
+  return moduleIds.reduce(function (bundles, moduleId) {
+    return bundles.concat(manifest[moduleId]);
+  }, []);
+}
+
+exports.ReactLoadablePlugin = ReactLoadablePlugin;
+exports.getBundles = getBundles;

--- a/src/babel.js
+++ b/src/babel.js
@@ -66,7 +66,7 @@ export default function({ types: t, template }) {
                     return t.callExpression(
                       t.memberExpression(
                       	t.identifier('require'),
-                        t.identifier('resolveWeak'),
+                        t.identifier('resolve'),
                       ),
                       [dynamicImport.get('arguments')[0].node],
                     )


### PR DESCRIPTION
I wanted to see if we could use this to do SSR with Meteor, but it turns out that SSR with React Loadable requires a webpack plugin. Meteor uses its own build system, so we can't use the webpack plugin. Meteor's dynamic import system is completely different from webpack anyway, in that it bundles are assembled at runtime based on individual requests for packages and files.

So I did a couple of things to make this work in Meteor - some of them are probably fine in general, but one change to the babel plugin may need to be better thought through.

What I did is to expose a new method on Loadable - `preloadablesReady`. I tried to keep everything in the spirit of the current API. This method works in practice a lot like `preloadReady` except it takes a list of modules to preload. This list is generated server side by the added `Capture.reportResolved` which will run the `webpack` method to get a translated rooted path (I didn't have any luck loading relative imports). The `preloadablesReady` method also skips the `isWebpackReady` method, since we are using Meteor and that check always fail.

Setting this up is pretty easy:

Server:
```JavaScript
import React from 'react'
import { StaticRouter } from 'react-router'
import { renderToString } from 'react-dom/server'
import { onPageLoad } from 'meteor/server-render'
import Loadable from 'react-loadable'
import App from '/imports/App'

Loadable.preloadAll().then(() => onPageLoad(sink => {
  const context = {}
  const modules = []
  const modulesResolved = []
  sink.renderIntoElementById('root', renderToString(
    <Loadable.Capture report={(moduleName) => { modules.push(moduleName) }}
      reportResolved={(resolvedModuleName) => { modulesResolved.push(resolvedModuleName) }}>
      <StaticRouter location={sink.request.url} context={context}>
        <App />
      </StaticRouter>
    </Loadable.Capture>
  ))
  sink.appendToBody(`<script>
  var preloadables = ${JSON.stringify(modulesResolved)}
</script>`)
```

Client:
```JavaScript
import { onPageLoad } from 'meteor/server-render'
import React from 'react'
import Loadable from 'react-loadable'
import { hydrate } from 'react-dom'
import { BrowserRouter } from 'react-router-dom'

onPageLoad(async sink => {
  let App = (await import('/imports/App')).default
  if (window.preloadables) {
    await Loadable.preloadablesReady(preloadables)
  }
  hydrate(
    <BrowserRouter><App /></BrowserRouter>,
    document.getElementById('root')
  )
})
```