### PR TITLE
Fix timedOut not being reset on retry.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -213,7 +213,7 @@ function createLoadableComponent(loadFn, options) {
     }
 
     retry = () => {
-      this.setState({ error: null, loading: true });
+      this.setState({ error: null, loading: true, timedOut: false });
       res = loadFn(opts.loader);
       this._loadModule();
     }


### PR DESCRIPTION
Hi 👋 

Was integrating with the new `retry` functionality introduced in #82 , really nice feature, the docs showcase using the `retry` prop when the `timedOut` prop has been set to `true`. However, the prop doesn't get reset on `retry` so the `Loading` component continues to received `timedOut: true` and never updates to the loading.

Simple fix just to default `timedOut: false` when you retry

Thanks for this great library!