### PR TITLE
Migrate from legacy to new React lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ class MyComponent extends React.Component {
     Bar: null
   };
 
-  componentWillMount() {
+  componentDidMount() {
     import('./components/Bar').then(Bar => {
       this.setState({ Bar });
     });

--- a/src/index.js
+++ b/src/index.js
@@ -149,7 +149,7 @@ function createLoadableComponent(loadFn, options) {
       return init();
     }
 
-    componentWillMount() {
+    componentDidMount() {
       this._mounted = true;
       this._loadModule();
     }


### PR DESCRIPTION
React will soon [deprecate](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#gradual-migration-path) `componentWillMount`, `componentWillReceiveProps` and `componentWillUpdate` methods due to their potential misuse, especially once async rendering is launched. In fact, enabling strict mode [already warns](https://reactjs.org/docs/strict-mode.html#identifying-unsafe-lifecycles) about these unsafe lifecycle methods usage.

This PR moves module loading logic from `componentWillMount` to `componentDidMount`, which is the recommended upgrade path in this case.