### PR TITLE
Adding readme for publicPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,6 +606,9 @@ res.send(`
       <script src="/dist/manifest.js"></script>
       ${bundles.map(bundle => {
         return `<script src="/dist/${bundle.file}"></script>`
+        // alternatively if you are using publicPath option in webpack config
+        // you can use the publicPath value from bundle, e.g:
+        // return `<script src="${bundle.publicPath}"></script>`
       }).join('\n')}
       <script src="/dist/main.js"></script>
     </body>


### PR DESCRIPTION
Adding docs for publicPath in README. 
I found the `publicPath` exists by seeing `react-loadable.json`, it would be nice to have it included in README.

It wasn't added when the code is added to the repo in PR #91 