### PR TITLE
Avoid error swallowing when exception is thrown during update cycle

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -199,6 +199,7 @@ function createLoadableComponent(loadFn, options) {
         update();
       }).catch(err => {
         update();
+        throw err;
       });
     }
 


### PR DESCRIPTION
I've recently came across a problem where an exception that was thrown into `componentDidMount()` on one of my components loaded with `react-loadable`. After some research, it appeared that exceptions thrown into `result.promise` were swallowed on subsequent updates, so I just added a `throw` clause to make them appear.

Schema to reproduce :

- Create a new class component with `componentDidMount()` and `render()` methods
- Encapsulate it into a loadable component created with `react-loadable`
- Trigger an exception in `componentDidMount()` (throw a new exception, assign this.isMounted, whatever you like)
- Console should be empty when trying to render your encapsulated component