### PR TITLE
Use webpack asset system instead of manually writing file

### DIFF
--- a/src/webpack.js
+++ b/src/webpack.js
@@ -1,6 +1,4 @@
 'use strict';
-const fs = require('fs');
-const path = require('path');
 const url = require('url');
 
 function buildManifest(compiler, compilation) {
@@ -39,15 +37,31 @@ class ReactLoadablePlugin {
     compiler.plugin('emit', (compilation, callback) => {
       const manifest = buildManifest(compiler, compilation);
       var json = JSON.stringify(manifest, null, 2);
-      const outputDirectory = path.dirname(this.filename);
-      try {
-        fs.mkdirSync(outputDirectory);
-      } catch (err) {
-        if (err.code !== 'EEXIST') {
-          throw err;
+      compilation.assets[this.filename] = {      
+        source() {
+          return json;
+        },
+
+        size() {
+          return json.length
+        },
+      
+        map(options) {
+          return null;
+        },
+      
+        node(options) {
+          return null;
+        },
+      
+        listMap(options) {
+          return null;
+        },
+      
+        updateHash(hash) {
+          hash.update(json);
         }
       }
-      fs.writeFileSync(this.filename, json);
       callback();
     });
   }

--- a/src/webpack.js
+++ b/src/webpack.js
@@ -41,25 +41,8 @@ class ReactLoadablePlugin {
         source() {
           return json;
         },
-
         size() {
           return json.length
-        },
-      
-        map(options) {
-          return null;
-        },
-      
-        node(options) {
-          return null;
-        },
-      
-        listMap(options) {
-          return null;
-        },
-      
-        updateHash(hash) {
-          hash.update(json);
         }
       }
       callback();


### PR DESCRIPTION
This makes sure webpack its `output.path` option is respected. 

Currently, when for example a library like Next.js implements the loader it will start writing the filename where the command is executed instead of where Next.js tells build files to go (`.next`).

These implemented methods are based on `RawSource` from `webpack-sources` [link](https://github.com/webpack/webpack-sources/blob/master/lib/RawSource.js), as this library brings dependencies like `source-map` and `source-list-map`. I decided it would be beneficial to only implement the methods required instead of adding a new dependency.

I wonder if this can be made non-breaking for existing implementations. It seems like webpack doesn't respect absolute file paths in `compilation.assets`