### PR TITLE
fix(README.md): correct FAQ example timeout unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1139,7 +1139,7 @@ export default function MyLoadable(opts) {
   return Loadable(Object.assign({
     loading: Loading,
     delay: 200,
-    timeout: 10,
+    timeout: 10000,
   }, opts));
 };
 ```


### PR DESCRIPTION
Unit for `timeout` is mistaken in the first example of FAQ.
Change FAQ example `timeout` unit from **10ms** to **10000ms**.