### PR TITLE
Pass props to Loading component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -226,7 +226,8 @@ function createLoadableComponent(loadFn, options) {
           pastDelay: this.state.pastDelay,
           timedOut: this.state.timedOut,
           error: this.state.error,
-          retry: this.retry
+          retry: this.retry,
+          props: this.props
         });
       } else if (this.state.loaded) {
         return opts.render(this.state.loaded, this.props);


### PR DESCRIPTION
There are cases when would want to render the loader with the props.
This passes the props to the loading component, so can render them in the loader.