### PR TITLE
Switched to using two layers of `.default` to workaround a webpack/node bug

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -84,7 +84,9 @@ function loadMap(obj) {
 }
 
 function resolve(obj) {
-  return obj && obj.__esModule ? obj.default : obj;
+  obj = obj && obj.default ? obj.default : obj
+  obj = obj && obj.default ? obj.default : obj
+  return obj;
 }
 
 function render(loaded, props) {


### PR DESCRIPTION
Node has added built-in support for dynamic imports with the `--experimental-modules` option, but it has a small issue with webpack. If you expected the result of import('./yourmodule') to be `{default: yourmodule}`, the issue causes the actual result to be `{default: {default: yourmodule}}`. (Note the extra default). I believe this is caused by node attempting to keep

Steps to reproduce buggy behavior:

1. Create files files `src/app.js` and `src/test.js`. 

2. Inside `src/app.js` write

```
// src/app.js
Promise.all([
    import('./test')
   ]).then(([
    testmodule,
    ]) => {
     console.log("obj: ", testguy);
    });
```

And inside `src/test.js` write

```
// src/test.js
console.log("ok")
const o = {a: "hello"}

export default o;
```

Now, building this with babel preset `stage-1` (from `yarn add babel-preset-stage-1`), after running you'll find the output is `obj:  [Module] { default: { default: { a: 'hello' } } }`, instead of the expected `obj:  [Module] default: { a: 'hello' } }`.

