### PR TITLE
Fix webpack 4.x deprecation warning

### DIFF
--- a/src/webpack.js
+++ b/src/webpack.js
@@ -36,7 +36,7 @@ class ReactLoadablePlugin {
   }
 
   apply(compiler) {
-    compiler.plugin('emit', (compilation, callback) => {
+    const emit = (compilation, callback) => {
       const manifest = buildManifest(compiler, compilation);
       var json = JSON.stringify(manifest, null, 2);
       const outputDirectory = path.dirname(this.filename);
@@ -50,6 +50,12 @@ class ReactLoadablePlugin {
       fs.writeFileSync(this.filename, json);
       callback();
     });
+    if (compiler.hooks) {
+      const plugin = { name: 'ReactLoadablePlugin' };
+      compiler.hooks.emit.tapAsync(plugin, emit);
+    } else {
+      compiler.plugin('emit', emit);
+    }
   }
 }
 


### PR DESCRIPTION
Fix warning in console:
```
DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead
```