### PR TITLE
Transform Object.assign with Babel in .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,5 +7,6 @@
   ],
   "plugins": [
     "transform-class-properties",
+    "transform-object-assign",
   ],
 }


### PR DESCRIPTION
Replaces `Object.assign` with an inline helper

Not sure if #85 used to work, but adding the plugin to the .babelrc applies the transform as expected