### PR TITLE
Enable usage as npm git dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "jest --coverage",
     "build": "babel src -d lib",
     "start": "yarn build && webpack && babel-node example/server.js",
-    "prepublish": "yarn build"
+    "prepare": "yarn build"
   },
   "dependencies": {
     "prop-types": "^15.5.0"


### PR DESCRIPTION
Hi! i swapped prepublish with prepare so this package can be used as a git dependency in package.json:
```
  "dependencies": {
    "react-loadable": "jamiebuilds/react-loadable#5.5.0"
  }
```

For details see: [https://github.com/npm/npm/issues/3055](npm/npm#3055)