### PR TITLE
[Feature] SSR assets manifest improved

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,11 +548,12 @@ import { ReactLoadablePlugin } from 'react-loadable/webpack';
 export default {
   plugins: [
     new ReactLoadablePlugin({
-      filename: './dist/react-loadable.json',
+      filename: 'react-loadable.json',
     }),
   ],
 };
 ```
+> For others available settings, see [Webpack Plugin Options](#options)
 
 Then we'll go back to our server and use this data to convert our modules to
 bundles.
@@ -1097,16 +1098,61 @@ import { ReactLoadablePlugin } from 'react-loadable/webpack';
 export default {
   plugins: [
     new ReactLoadablePlugin({
-      filename: './dist/react-loadable.json',
+      filename: 'react-loadable.json',
     }),
   ],
 };
 ```
 
-This will create a file (`opts.filename`) which you can import to map modules
-to bundles.
+This will create an assets manifest (`opts.filename`) which you can import to
+ map modules to bundles.
+
 
 [Read more about mapping modules to bundles](#mapping-loaded-modules-to-bundles).
+
+### options
+
+#### `filename`
+
+Type: `string`
+Default: `react-loadable.json`
+
+Assets manifest file name. May contain relative or absolute path.
+
+
+#### `integrity`
+
+Type: `boolean`
+Default: `false`
+
+Enable or disable generation of [Subresource Integrity (SRI).](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) hash.
+
+#### `integrityAlgorithms`
+
+Type: `array`
+Default: `[ 'sha256', 'sha384', 'sha512' ]`
+
+Algorithms to generate hash.
+
+
+#### `integrityPropertyName`
+
+Type: `string`
+Default: `integrity`
+
+Custom property name to be output in the assets manifest file.
+
+
+**Full configuration example**
+
+```js
+new ReactLoadablePlugin({
+  filename: 'react-loadable.json',
+  integrity: false,
+  integrityAlgorithms: [ 'sha256', 'sha384', 'sha512' ],
+  integrityPropertyName: 'integrity',
+}),
+```
 
 ### `getBundles`
 
@@ -1194,8 +1240,8 @@ you care about:
 ```js
 let bundles = getBundles(stats, modules);
 
-let styles = bundles.filter(bundle => bundle.file.endsWith('.css'));
-let scripts = bundles.filter(bundle => bundle.file.endsWith('.js'));
+let styles = bundles.css || [];
+let scripts = bundles.js || [];
 
 res.send(`
   <!doctype html>

--- a/example/server.js
+++ b/example/server.js
@@ -16,11 +16,11 @@ app.get('/', (req, res) => {
       <App/>
     </Loadable.Capture>
   );
-
+  
   let bundles = getBundles(stats, modules);
 
-  let styles = bundles.filter(bundle => bundle.file.endsWith('.css'));
-  let scripts = bundles.filter(bundle => bundle.file.endsWith('.js'));
+  let styles = bundles.css || [];
+  let scripts = bundles.js || [];
 
   res.send(`
     <!doctype html>

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,34 @@
+const crypto = require('crypto');
+
+/**
+ * See {@link https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity|Subresource Integrity} at MDN
+ *
+ * @param  {array} algorithms - The algorithms you want to use when hashing `content`
+ * @param  {string} source - File contents you want to hash
+ * @return {string} SRI hash
+ */
+const computeIntegrity = (algorithms, source) =>
+  Array.isArray(algorithms) ? algorithms
+    .map(algorithm => {
+      const hash = crypto
+        .createHash(algorithm)
+        .update(source, "utf8")
+        .digest("base64");
+      return `${algorithm}-${hash}`;
+    })
+    .join(' ') : '';
+
+/**
+ * toArray
+ *
+ * @desc Check and convert given data to Array, if needed.
+ * @param  {string|array} data
+ * @return {array}
+ */
+const toArray = data =>  Array.isArray(data) ? data : [data];
+
+
+module.exports = {
+  computeIntegrity,
+  toArray,
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -18,17 +18,6 @@ const computeIntegrity = (algorithms, source) =>
     })
     .join(' ') : '';
 
-/**
- * toArray
- *
- * @desc Check and convert given data to Array, if needed.
- * @param  {string|array} data
- * @return {array}
- */
-const toArray = data =>  Array.isArray(data) ? data : [data];
-
-
 module.exports = {
   computeIntegrity,
-  toArray,
 };

--- a/src/webpack.js
+++ b/src/webpack.js
@@ -2,61 +2,161 @@
 const fs = require('fs');
 const path = require('path');
 const url = require('url');
+const { computeIntegrity, toArray, } = require('./utils');
 
-function buildManifest(compiler, compilation) {
-  let context = compiler.options.context;
-  let manifest = {};
+const PLUGIN_NAME = 'ReactLoadablePlugin';
 
-  compilation.chunks.forEach(chunk => {
-    chunk.files.forEach(file => {
-      chunk.forEachModule(module => {
-        let id = module.id;
-        let name = typeof module.libIdent === 'function' ? module.libIdent({ context }) : null;
-        let publicPath = url.resolve(compilation.outputOptions.publicPath || '', file);
-        
-        let currentModule = module;
-        if (module.constructor.name === 'ConcatenatedModule') {
-          currentModule = module.rootModule;
-        }
-        if (!manifest[currentModule.rawRequest]) {
-          manifest[currentModule.rawRequest] = [];
-        }
-
-        manifest[currentModule.rawRequest].push({ id, name, file, publicPath });
-      });
-    });
-  });
-
-  return manifest;
-}
+const defaultOptions = {
+  filename: 'react-loadable.json',
+  integrity: false,
+  integrityAlgorithms: [ 'sha256', 'sha384', 'sha512' ],
+  integrityPropertyName: 'integrity',
+};
 
 class ReactLoadablePlugin {
-  constructor(opts = {}) {
-    this.filename = opts.filename;
+  constructor(options = defaultOptions) {
+    this.options = Object.assign({}, defaultOptions, options);
+    this.compiler = null;
+    this.stats = null;
+    this.entrypoints = new Set();
+    this.assetsByName = new Map();
+    this.manifest = {};
   }
 
   apply(compiler) {
-    compiler.plugin('emit', (compilation, callback) => {
-      const manifest = buildManifest(compiler, compilation);
-      var json = JSON.stringify(manifest, null, 2);
-      const outputDirectory = path.dirname(this.filename);
-      try {
-        fs.mkdirSync(outputDirectory);
-      } catch (err) {
-        if (err.code !== 'EEXIST') {
-          throw err;
-        }
-      }
-      fs.writeFileSync(this.filename, json);
-      callback();
+    this.compiler = compiler;
+    if (compiler.hooks) {
+      compiler.hooks.emit.tapAsync(PLUGIN_NAME, this.handleEmit.bind(this));
+    } else {
+      compiler.plugin('emit', this.handleEmit.bind(this));
+    }
+  }
+
+  handleEmit(compilation, callback) {
+    this.stats = compilation.getStats().toJson();
+    this.options.publicPath = (compilation.outputOptions ? compilation.outputOptions.publicPath : compilation.options.output.publicPath) || '';
+    this.getEntrypoints(this.stats.entrypoints);
+    this.getAssets(this.stats.chunks);
+    this.processAssets(compilation.assets);
+    this.writeAssetsFile();
+
+    callback();
+  }
+
+  getAssets(assetsChunk) {
+    assetsChunk.forEach(chunk => {
+      const { id: chunkName, files, hash } = chunk;
+      const id = chunk.origins[0].request
+        || chunk.names.length > 0 && chunk.names[0]
+        || chunk.modules[0].reasons[0].userRequest
+        || chunkName;
+
+      this.assetsByName.set(id, { files, hash, });
     });
+
+    return this.assetsByName;
+  }
+
+  getEntrypoints(entrypoints) {
+    Object.keys(entrypoints).forEach(entry => this.entrypoints.add(entry));
+    return this.entrypoints;
+  }
+
+  isRequestFromDevServer() {
+    if (process.argv.some( arg => arg.includes('webpack-dev-server') ) ) { return true; }
+    return this.compiler.outputFileSystem && this.compiler.outputFileSystem.constructor.name === 'MemoryFileSystem';
+  }
+
+  getFileExtension(filename) {
+    if (!filename || typeof filename !== 'string') { return ''; }
+
+    const fileExtRegex = /\.\w{2,4}\.(?:map|gz)$|\.\w+$/i;
+
+    filename = filename.split(/[?#]/)[0];
+    const ext = filename.match(fileExtRegex);
+
+    return ext && ext.length ? ext[0] : '';
+  };
+
+  getManifestOutputPath() {
+    if (path.isAbsolute(this.options.filename)) {
+      return this.options.filename;
+    }
+
+    if (this.isRequestFromDevServer()) {
+      let outputPath = (this.compiler.options.devServer.outputPath || this.compiler.outputPath || '/');
+
+      if (outputPath === '/' ) {
+        console.warn('Please use an absolute path in options.output when using webpack-dev-server.');
+        outputPath = this.compiler.context || process.cwd();
+      }
+
+      return path.resolve(outputPath, this.options.filename);
+    }
+
+    return path.resolve(this.compiler.outputPath, this.options.filename);
+
+  };
+
+  processAssets(originAssets) {
+    const assets = {};
+    const { entrypoints } = this;
+
+    for (const [ id, value ] of this.assetsByName) {
+      value.files.forEach(file => {
+        const currentAsset = originAssets[file];
+        const ext = this.getFileExtension(file).replace(/^\.+/, '').toLowerCase();
+        if (!assets[id]) { assets[id] = {}; }
+        if (!assets[id][ext]) { assets[id][ext] = []; }
+
+        if (currentAsset && this.options.integrity && !currentAsset[this.options.integrityPropertyName]) {
+          currentAsset[this.options.integrityPropertyName] = computeIntegrity(this.options.integrityAlgorithms, currentAsset.source())
+        }
+
+        assets[id][ext].push({
+          file,
+          hash: value.hash,
+          publicPath: url.resolve(this.options.publicPath || '', file),
+          integrity: currentAsset[this.options.integrityPropertyName],
+        });
+      });
+    }
+
+    this.manifest = {
+      entrypoints: Array.from(entrypoints),
+      assets,
+    }
+  }
+
+  writeAssetsFile() {
+    const filePath = this.getManifestOutputPath();
+    const fileDir = path.dirname(filePath);
+    const json = JSON.stringify(this.manifest, null, 2);
+    try {
+      if (!fs.existsSync(fileDir)) {
+        fs.mkdirSync(fileDir);
+      }
+    } catch (err) {
+      if (err.code !== 'EEXIST') {
+        throw err;
+      }
+    }
+
+    fs.writeFileSync(filePath, json);
   }
 }
 
-function getBundles(manifest, moduleIds) {
-  return moduleIds.reduce((bundles, moduleId) => {
-    return bundles.concat(manifest[moduleId]);
-  }, []);
+function getBundles(manifest, chunks) {
+  return chunks.reduce((bundle, chunk) => {
+    if (manifest.assets[chunk]) {
+      Object.keys(manifest.assets[chunk]).forEach(key => {
+        const content = manifest.assets[chunk][key];
+        if (!bundle[key]) { bundle[key] = []; }
+        bundle[key] = [...bundle[key], ...content];
+      });
+    }
+    return bundle;
+  }, {});
 }
 
 exports.ReactLoadablePlugin = ReactLoadablePlugin;


### PR DESCRIPTION
Hello,

During the use of the `react-loadable` in the `server side`, I realised that the old `Webpack Plugin` was generating a **huge assets manifest file**, with records other than the actual assets.

Besides that, I found a need to use [SRI (Subresource Integrity)](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity), which requires all assets to have a `base64 hash`.

So, I rebuilt the whole Webpack Plugin, generating the output from the assets manifest file with only the actual assets, including the application entry points, which I find to be very useful, following the format bellow, extract from the `ssr example`, separated by `file type group`:

```json
{
  "entrypoints": [
    "main"
  ],
  "origins": {
    "./Example": [
      0
    ],
    "./ExampleNested": [
      1
    ],
    "main": [
      2
    ]
  },
  "assets": {
    "0": {
      "js": [
        {
          "file": "0.js",
          "hash": "fdb00ffa16dfaf9cef0a",
          "publicPath": "/dist/0.js",
          "integrity": "sha256-Xxf7WVjPbdkJjgiZt7mvZvYv05+uErTC9RC2yCHF1RM= sha384-9OgouqlzN9KrqXVAcBzVMnlYOPxOYv/zLBOCuYtUAMoFxvmfxffbNIgendV4KXSJ sha512-oUxk3Swi0xIqvIxdWzXQIDRYlXo/V/aBqSYc+iWfsLcBftuIx12arohv852DruxKmlqtJhMv7NZp+5daSaIlnw=="
        }
      ]
    },
    "1": {
      "js": [
        {
          "file": "1.js",
          "hash": "7e88ef606abbb82d7e82",
          "publicPath": "/dist/1.js",
          "integrity": "sha256-ZPrPWVJRjdS4af9F1FzkqTqqSGo1jYyXNyctwTOLk9o= sha384-J1wiEV8N1foqRF7W9SEvg2s/FhQbhpKFHBTNBJR8g1yEMNRMi38y+8XmjDV/Iu7w sha512-b16+PXStO68CP52R+0ZktccMiaI1v0jOy34l/DqyGN7kEae3DpV3xPNoC8vt1WfE1kCAH7dlnHDdp1XRVhZX+g=="
        }
      ]
    },
    "2": {
      "js": [
        {
          "file": "main.js",
          "hash": "0cbd05b10204597c781d",
          "publicPath": "/dist/main.js",
          "integrity": "sha256-sGdw+WVvXK1ZVQnYHI4FpecOcZtWZ99576OHCdrGil8= sha384-DZZzkPtPCTCR5UOWuGCyXQvsjyvZPoreCzqQGyrNV8+HyV9MdoYZawHX7NdGGLyi sha512-y29BlwBuwKB+BeXrrQYEBrK+mfWuOb4ok6F57kGbtrwa/Xq553Zb7lgss8RNvFjBSaMUdvXiJuhmP3HZA0jNeg=="
        }
      ]
    }
  }
}
```

In that way, **we also provide support for `splitted chunks`** once we explicit inform all the assets required for the `origin` we are trying to render.

That said, the new options added to the Webpack Plugin, described as well in the README.md:

```js
new ReactLoadablePlugin({
  filename: 'react-loadable.json',
  integrity: false,
  integrityAlgorithms: [ 'sha256', 'sha384', 'sha512' ],
  integrityPropertyName: 'integrity',
})
```

Also, it's super easy to get the content type that you want, as in the following example:

```js
let bundles = getBundles(stats, modules);

let styles = bundles.css || [];
let scripts = bundles.js || [];
```

PS: It was maintained **compatibility with Webpack 3+**

That's it!

----------
