### PR TITLE
Bug: "__esModule" is undefined cause React.createElement receive "obj…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,7 @@ function loadMap(obj) {
 }
 
 function resolve(obj) {
-  return obj && obj.__esModule ? obj.default : obj;
+  return obj && obj.default ? obj.default : obj;
 }
 
 function render(loaded, props) {


### PR DESCRIPTION
…ect" not function

    "webpack": "^4.6.0",
    "babel-core": "^6.26.2",
    "babel-eslint": "^8.2.3",
    "babel-loader": "^7.1.4",
    "babel-plugin-add-module-exports": "^0.2.1",
    "babel-plugin-dva-hmr": "^0.4.1",
    "babel-plugin-import": "^1.7.0",
    "babel-plugin-syntax-dynamic-import": "^6.18.0",
    "babel-plugin-transform-async-to-generator": "^6.24.1",
    "babel-plugin-transform-decorators-legacy": "^1.3.4",
    "babel-plugin-transform-runtime": "^6.23.0",
    "babel-preset-env": "^1.6.1",
    "babel-preset-react": "^6.24.1",
    "babel-preset-stage-0": "^6.24.1",