### PR TITLE
Throw errors that occur during render

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -209,7 +209,7 @@ function createLoadableComponent(loadFn, options) {
           update();
         })
         .catch(err => {
-          update();
+          throw err;
         });
     }
 


### PR DESCRIPTION
I've been using react-loadable in a create-react-app application, and have found that errors thrown during the rendering of a resolved component are getting swallowed by react-loadable. Presently an error during render will not log anything meaningful in the console. I think it is preferable that they throw exception which react-error-overlay can catch and display.