### PR TITLE
Support passing children to the loading component

### DIFF
--- a/README.md
+++ b/README.md
@@ -747,6 +747,17 @@ Loadable({
 });
 ```
 
+#### `opts.children`
+
+This boolean option controls whether `children` will be passed to the [`LoadingComponent`](#loadingcomponent)
+
+```js
+Loadable({
+  loading: ({ children }) => <div>{children}</div>,
+  children: true
+});
+```
+
 #### `opts.delay`
 
 Time to wait (in milliseconds) before passing

--- a/__tests__/__snapshots__/test.js.snap
+++ b/__tests__/__snapshots__/test.js.snap
@@ -1,5 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`allow children 1`] = `
+<span>
+  Hello World
+</span>
+`;
+
+exports[`allow children 2`] = `
+<h1>
+  Hello World
+</h1>
+`;
+
 exports[`delay and timeout 1`] = `
 <div>
   MyLoadingComponent 

--- a/__tests__/test.js
+++ b/__tests__/test.js
@@ -201,6 +201,22 @@ test('loadable map error', async () => {
   expect(component.toJSON()).toMatchSnapshot(); // success
 });
 
+test('allow children', async () => {
+  let LoadableMyComponent = Loadable({
+    loader: createLoader(100, () => ({ children }) => <h1>{children}</h1>),
+    loading: ({ children }) => <span>{children}</span>,
+    children: true
+  });
+
+  let component1 = renderer.create(
+    <LoadableMyComponent>Hello World</LoadableMyComponent>
+  );
+
+  expect(component1.toJSON()).toMatchSnapshot(); // initial
+  await waitFor(200);
+  expect(component1.toJSON()).toMatchSnapshot(); // loaded
+});
+
 describe('preloadReady', () => {
   beforeEach(() => {
     global.__webpack_modules__ = { 1: true, 2: true };

--- a/src/index.js
+++ b/src/index.js
@@ -231,13 +231,19 @@ function createLoadableComponent(loadFn, options) {
 
     render() {
       if (this.state.loading || this.state.error) {
-        return React.createElement(opts.loading, {
+        const props = {
           isLoading: this.state.loading,
           pastDelay: this.state.pastDelay,
           timedOut: this.state.timedOut,
           error: this.state.error,
-          retry: this.retry
-        });
+          retry: this.retry,
+        };
+
+        if (opts.children) {
+          props.children = this.props.children;
+        }
+
+        return React.createElement(opts.loading, props);
       } else if (this.state.loaded) {
         return opts.render(this.state.loaded, this.props);
       } else {


### PR DESCRIPTION
In our use case, rendering the `children` while displaying the loading component is critical for performance reason.
This PR adds the support in a backward-compatible way.