### PR TITLE
Support emitting assets via webpack build

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "prepublish": "yarn build"
   },
   "dependencies": {
-    "prop-types": "^15.5.0"
+    "prop-types": "^15.5.0",
+    "webpack-sources": "^1.3.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,7 +43,9 @@ module.exports = {
   },
   plugins: [
     new ReactLoadablePlugin({
-      filename:  path.resolve(__dirname, 'example', 'dist', 'react-loadable.json'),
+      writeToDisk: false,
+      emitAssets: true,
+      filename: 'react-loadable.json',
     }),
   ]
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4156,6 +4156,10 @@ source-map@~0.5.3:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
+source-map@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+
 spdx-correct@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-1.0.2.tgz#4b3073d933ff51f3912f03ac5519498a4150db40"
@@ -4604,6 +4608,13 @@ webpack-sources@^1.0.1:
   dependencies:
     source-list-map "^2.0.0"
     source-map "~0.5.3"
+
+webpack-sources@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.3.0.tgz#2a28dcb9f1f45fe960d8f1493252b5ee6530fa85"
+  dependencies:
+    source-list-map "^2.0.0"
+    source-map "~0.6.1"
 
 webpack@^3.6.0:
   version "3.6.0"


### PR DESCRIPTION
The webpack loader currently outputs a file directly to dist, which can then be picked up by the consumer's server render.
It's possible to pass in custom file systems to webpack, such as [memory-fs](https://github.com/webpack/memory-fs).

This change allows the loader to optionally output assets directly into the Webpack output.
This change is non-breaking, and opted into by passing `emitAssets: true`.

I believe it may make sense to have `emitAssets` be the default behaviour, but that could break consumer builds.

# Examples

**Write to disk**
``` js
    new ReactLoadablePlugin({
      writeToDisk: true, // or undefined
      filename:  path.resolve(__dirname, 'example', 'dist', 'react-loadable.json'),
    })
```

**Emit to Webpack assets**
``` js
    new ReactLoadablePlugin({
      writeToDisk: false,
      emitAssets: true,
      filename: 'react-loadable.json',
    })
```
**Example output of emitting assets**
<img width="481" alt="Example webpack output including a react-loadable.json file." src="https://user-images.githubusercontent.com/13903378/46587292-d084a980-cad5-11e8-8246-63e988c0be5f.png">
