### PR TITLE
Avoids runaway promise in res.promise

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -207,9 +207,11 @@ function createLoadableComponent(loadFn, options) {
       res.promise
         .then(() => {
           update();
+          return null;
         })
         .catch(err => {
           update();
+          return null;
         });
     }
 


### PR DESCRIPTION
https://github.com/petkaantonov/bluebird/blob/master/docs/docs/warning-explanations.md#warning-a-promise-was-created-in-a-handler-but-was-not-returned-from-it