### PR TITLE
Remove use of componentWillMount

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-loadable",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "description": "A higher order component for loading components with promises",
   "main": "lib/index.js",
   "author": "James Kyle <me@thejameskyle.com>",

--- a/src/index.js
+++ b/src/index.js
@@ -158,7 +158,7 @@ function createLoadableComponent(loadFn, options) {
       return init();
     }
 
-    componentWillMount() {
+    componentDidMount() {
       this._mounted = true;
       this._loadModule();
     }


### PR DESCRIPTION
React 16.9.0 [deprecated](https://reactjs.org/blog/2019/08/08/react-v16.9.0.html#renaming-unsafe-lifecycle-methods) `componentWillMount` so it now throws a warning when used. 

As far as I can see this should be a simple swap to `componentDidMount`