### PR TITLE
Change tc39's proposal dynamic-import stage 3 to stage 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ class Foo extends React.Component {
 Right now we're depending on `Bar` being imported synchronously via `import`,
 but we don't need it until we go to render it. So why don't we just defer that?
 
-Using a **dynamic import** ([a tc39 proposal currently at Stage 3](https://github.com/tc39/proposal-dynamic-import))
+Using a **dynamic import** ([a tc39 proposal currently at Stage 4](https://github.com/tc39/proposal-dynamic-import))
 we can modify our component to load `Bar` asynchronously.
 
 ```js


### PR DESCRIPTION
As I was reading the documentation about tc39's dynamic-import proposal, I saw the current stage is 4. The current README.md of react-loadable reads stage 3.

It became stage 4 on the 20th of june 2019.

Sources: 
* [Github tc39/proposal-dynamic-import](https://github.com/tc39/proposal-dynamic-import)
* [tc39.es/proposal-dynamic-import](https://tc39.es/proposal-dynamic-import/)