### PR TITLE
Rename unsafe lifecycle hooks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -158,7 +158,7 @@ function createLoadableComponent(loadFn, options) {
       return init();
     }
 
-    componentWillMount() {
+    UNSAFE_componentWillMount() {
       this._mounted = true;
       this._loadModule();
     }


### PR DESCRIPTION
1. Unsafe lifecycles hook will not work from React v17.x without prefix with UNSAFE_
2. This will fix the warning message in React v16.9.0