### PR TITLE
Use compiler.outputFileSystem and make manifest generation externally accessible

### DIFF
--- a/src/webpack.js
+++ b/src/webpack.js
@@ -1,7 +1,6 @@
-'use strict';
-const fs = require('fs');
-const path = require('path');
-const url = require('url');
+"use strict";
+const path = require("path");
+const url = require("url");
 
 function buildManifest(compiler, compilation) {
   let context = compiler.options.context;
@@ -11,11 +10,17 @@ function buildManifest(compiler, compilation) {
     chunk.files.forEach(file => {
       chunk.forEachModule(module => {
         let id = module.id;
-        let name = typeof module.libIdent === 'function' ? module.libIdent({ context }) : null;
-        let publicPath = url.resolve(compilation.outputOptions.publicPath || '', file);
-        
+        let name =
+          typeof module.libIdent === "function"
+            ? module.libIdent({ context })
+            : null;
+        let publicPath = url.resolve(
+          compilation.outputOptions.publicPath || "",
+          file
+        );
+
         let currentModule = module;
-        if (module.constructor.name === 'ConcatenatedModule') {
+        if (module.constructor.name === "ConcatenatedModule") {
           currentModule = module.rootModule;
         }
         if (!manifest[currentModule.rawRequest]) {
@@ -36,18 +41,18 @@ class ReactLoadablePlugin {
   }
 
   apply(compiler) {
-    compiler.plugin('emit', (compilation, callback) => {
+    compiler.plugin("emit", (compilation, callback) => {
       const manifest = buildManifest(compiler, compilation);
       var json = JSON.stringify(manifest, null, 2);
       const outputDirectory = path.dirname(this.filename);
       try {
-        fs.mkdirSync(outputDirectory);
+        compiler.outputFileSystem.mkdirSync(outputDirectory);
       } catch (err) {
-        if (err.code !== 'EEXIST') {
+        if (err.code !== "EEXIST") {
           throw err;
         }
       }
-      fs.writeFileSync(this.filename, json);
+      compiler.outputFileSystem.writeFileSync(this.filename, json);
       callback();
     });
   }

--- a/src/webpack.js
+++ b/src/webpack.js
@@ -66,3 +66,4 @@ function getBundles(manifest, moduleIds) {
 
 exports.ReactLoadablePlugin = ReactLoadablePlugin;
 exports.getBundles = getBundles;
+exports.buildManifest = buildManifest;


### PR DESCRIPTION
use compiler.outputFileSystem instead of native fs module

we prefer to use `memory-fs` in dev mode ( eg: webpack-dev-middleware), current implements in this plugin using native `fs` module may produce conflicts in code.

Also making the manifest creation externally accessible. 