### PR TITLE
Updated componentWillMount to componentDidMount

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -158,7 +158,7 @@ function createLoadableComponent(loadFn, options) {
       return init();
     }
 
-    componentWillMount() {
+    componentDidMount() {
       this._mounted = true;
       this._loadModule();
     }
@@ -213,7 +213,7 @@ function createLoadableComponent(loadFn, options) {
         });
     }
 
-    componentWillUnmount() {
+    componentDidUnmount() {
       this._mounted = false;
       this._clearTimeouts();
     }


### PR DESCRIPTION
I was using this in my project and i saw its using componentWillMount which will be deprected in the new version of react so i updated it with componentDidMount. To avoid deprecation and remove the warning