### PR TITLE
componentWillMount removed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -158,12 +158,9 @@ function createLoadableComponent(loadFn, options) {
       return init();
     }
 
-    componentWillMount() {
-      this._loadModule();
-    }
-
     componentDidMount() {
       this._mounted = true;
+      this._loadModule();
     }
 
     _loadModule() {


### PR DESCRIPTION
removed `componentWillMount` and moved `this._loadModule();` into `componentDidMount`.

squashes the warning as `componentWillMount` was marked as `UNSAFE_componentWillMount()`.