### PR TITLE
Found a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ function Loading(props) {
 }
 ```
 
-This delay defaults to `200ms` but you can also customize the
+This delay defaults to `300ms` but you can also customize the
 [delay](#optsdelay) in `Loadable`.
 
 ```js


### PR DESCRIPTION
Dear Maintainer

I just found a typo. In example code, it delays 0.3s while in text it shows `300ms`.

Best Regards,

Frank