### PR TITLE
feat: post props to loading Component

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -245,7 +245,8 @@ function createLoadableComponent(loadFn, options) {
           pastDelay: this.state.pastDelay,
           timedOut: this.state.timedOut,
           error: this.state.error,
-          retry: this.retry
+          retry: this.retry,
+          initialProps: this.props
         });
       } else if (this.state.loaded) {
         return opts.render(this.state.loaded, this.props);

--- a/src/index.js
+++ b/src/index.js
@@ -246,7 +246,7 @@ function createLoadableComponent(loadFn, options) {
           timedOut: this.state.timedOut,
           error: this.state.error,
           retry: this.retry,
-          initialProps: this.props
+          props: this.props
         });
       } else if (this.state.loaded) {
         return opts.render(this.state.loaded, this.props);


### PR DESCRIPTION
I met a situation that the loading part could not met my need. The situation is like that:
```
const Loading = (props) => {
    if ( props.condition) {
        return <A {...props} />;
    } else {
        return <B {...props} />;
    }
}
```
Maybe leave a channel to post props is needed.