### PR TITLE
Add Kapwing to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ export default class App extends React.Component {
 - [Gogo](https://gogoair.com)
 - [Gofore](https://gofore.com/en/home/)
 - [Graana](https://www.graana.com/)
+- [Kapwing](https://www.kapwing.com/)
 - [Localie](https://localie.co/en)
 - [MediaTek MCS-Lite](https://github.com/MCS-Lite)
 - [NiYO Solutions Inc.](https://www.goniyo.com/)


### PR DESCRIPTION
We use react-loadable at Kapwing in order to load many of our client side components. It has improved our bundle size as well as our Google scores a lot! We'd love if we could be included in the example list. Thanks!