### PR TITLE
Fix DeprecationWarning: Chunk.forEachModule

### DIFF
--- a/src/webpack.js
+++ b/src/webpack.js
@@ -7,7 +7,7 @@ function buildManifest(compiler, compilation) {
 
   compilation.chunks.forEach(chunk => {
     chunk.files.forEach(file => {
-      chunk.forEachModule(module => {
+      for(const module of chunk.modulesIterable) {
         let id = module.id;
         let name = typeof module.libIdent === 'function' ? module.libIdent({ context }) : null;
         let publicPath = url.resolve(compilation.outputOptions.publicPath || '', file);
@@ -21,7 +21,7 @@ function buildManifest(compiler, compilation) {
         }
 
         manifest[currentModule.rawRequest].push({ id, name, file, publicPath });
-      });
+      }
     });
   });
 


### PR DESCRIPTION
DeprecationWarning: Chunk.forEachModule: Use for(const module of chunk.modulesIterable) instead