### PR TITLE
Add Online Solitaire to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ export default class App extends React.Component {
 - [MediaTek MCS-Lite](https://github.com/MCS-Lite)
 - [NiYO Solutions Inc.](https://www.goniyo.com/)
 - [Officepulse](https://www.officepulse.in/)
+- [Online Solitaire](https://online-solitaire.com/)
 - [PageSpeed Green](https://pagespeed.green/)
 - [Perx](https://www.perxtech.com/)
 - [Plottu](https://public.plottu.com)


### PR DESCRIPTION
I run https://online-solitaire.com/, a website where more than 4 million solitaire games are played each month. I make pretty heavy use of react-loadable to speed up the site, so I thought it might be a nice example in the users list.