### PR TITLE
add judgment on vite packaging results

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,11 @@ function loadMap(obj) {
 }
 
 function resolve(obj) {
-  return obj && obj.__esModule ? obj.default : obj;
+  const symbolKey = Object.getOwnPropertySymbols(obj).find(key => key.toString() === 'Symbol(Symbol.toStringTag)')
+  if(obj.__esModule || obj[symbolKey]==='Module'){
+    return obj.default
+  }
+  else return obj
 }
 
 function render(loaded, props) {


### PR DESCRIPTION
"React. CreateElement: type is invalid..." error will appear when using "vite" to package the react project
The module obtained by using “import("xxx").then (module = > console.log (module))“ syntax in vite will be marked as "symbol (symbol. Tostringtag)": "module" The judgment in the 'resolve' function is "__esmodule: true", so the packaged user of "vite" should add the judgment after "vite" packaging, otherwise the packaged user of "vite" will not be able to use