### PR TITLE
Replace componentWillMount with UNSAFE_componentWillMount

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -158,7 +158,7 @@ function createLoadableComponent(loadFn, options) {
       return init();
     }
 
-    componentWillMount() {
+    UNSAFE_componentWillMount() {
       this._loadModule();
     }
 


### PR DESCRIPTION
componentWillMount has been renamed, and is not recommended for use
Rename componentWillMount to UNSAFE_componentWillMount to suppress this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work.
